### PR TITLE
add streaming /api/qa endpoint backed by ai-sdk

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,15 +5,20 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build"
+    "build": "tsc -b && vite build",
+    "start": "tsx server/index.ts"
   },
   "dependencies": {
+    "@hono/node-server": "^1.13.7",
+    "@spr26/ai-service": "*",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/react-router": "^1.168.22",
+    "hono": "^4.9.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-icons": "^5.6.0",
     "tailwindcss": "^4.2.2",
+    "tsx": "^4.21.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/apps/web/server/index.ts
+++ b/apps/web/server/index.ts
@@ -1,0 +1,85 @@
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { serve } from "@hono/node-server";
+import { serveStatic } from "@hono/node-server/serve-static";
+import {
+  parseQaInput,
+  streamAnswer,
+  type TranscriptItem,
+} from "@spr26/ai-service";
+import { Hono } from "hono";
+import { streamSSE } from "hono/streaming";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const APP_ROOT = resolve(HERE, "..");
+const TRANSCRIPT_PATH = resolve(APP_ROOT, "src", "data", "transcript.json");
+const DIST_DIR = resolve(APP_ROOT, "dist");
+const INDEX_HTML = resolve(DIST_DIR, "index.html");
+
+// serveStatic resolves `root` relative to cwd; pin it so the script works
+// regardless of where it was launched from.
+process.chdir(APP_ROOT);
+
+const app = new Hono();
+
+app.all("/api/qa", async (c) => {
+  const url = new URL(c.req.url);
+
+  let question: string | null;
+  if (c.req.method === "GET") {
+    question = url.searchParams.get("q");
+  } else if (c.req.method === "POST") {
+    try {
+      const body = await c.req.json<{ question?: string }>();
+      question = body.question ?? null;
+    } catch {
+      return c.json({ error: "invalid JSON body" }, 400);
+    }
+  } else {
+    return c.json({ error: "method not allowed" }, 405);
+  }
+
+  const raw = await readFile(TRANSCRIPT_PATH, "utf8");
+  const transcript = JSON.parse(raw) as TranscriptItem[];
+
+  const parsed = parseQaInput({
+    t: url.searchParams.get("t"),
+    question,
+    transcript,
+  });
+  if (!parsed.ok) {
+    return c.json({ error: parsed.error }, parsed.status);
+  }
+
+  c.header("cache-control", "no-cache");
+  c.header("x-accel-buffering", "no");
+  return streamSSE(c, async (stream) => {
+    try {
+      for await (const delta of streamAnswer(parsed)) {
+        await stream.writeSSE({ data: JSON.stringify({ delta }) });
+      }
+      await stream.writeSSE({ event: "done", data: '"[DONE]"' });
+    } catch (err) {
+      await stream.writeSSE({
+        event: "error",
+        data: JSON.stringify({
+          error: err instanceof Error ? err.message : "internal error",
+        }),
+      });
+    }
+  });
+});
+
+app.use("/*", serveStatic({ root: "./dist" }));
+
+// SPA fallback for client-side routes.
+app.get("/*", async (c) => {
+  const html = await readFile(INDEX_HTML, "utf8");
+  return c.html(html);
+});
+
+const port = Number(process.env.PORT ?? 3000);
+serve({ fetch: app.fetch, port }, ({ port }) => {
+  console.log(`server listening on http://localhost:${port}`);
+});

--- a/apps/web/server/qa-plugin.ts
+++ b/apps/web/server/qa-plugin.ts
@@ -1,0 +1,107 @@
+import { readFile } from "node:fs/promises";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { resolve } from "node:path";
+import {
+  parseQaInput,
+  streamAnswer,
+  type TranscriptItem,
+} from "@spr26/ai-service";
+import type { Plugin } from "vite";
+
+const TRANSCRIPT_PATH = resolve(
+  import.meta.dirname,
+  "..",
+  "src",
+  "data",
+  "transcript.json",
+);
+
+async function readJsonBody(req: IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) chunks.push(chunk as Buffer);
+  const raw = Buffer.concat(chunks).toString("utf8");
+  if (!raw) return {};
+  return JSON.parse(raw);
+}
+
+function sendJson(res: ServerResponse, status: number, body: unknown) {
+  res.statusCode = status;
+  res.setHeader("content-type", "application/json");
+  res.end(JSON.stringify(body));
+}
+
+function writeSseEvent(
+  res: ServerResponse,
+  data: unknown,
+  event?: string,
+): void {
+  if (event) res.write(`event: ${event}\n`);
+  res.write(`data: ${JSON.stringify(data)}\n\n`);
+}
+
+async function handle(req: IncomingMessage, res: ServerResponse) {
+  const url = new URL(req.url ?? "/", "http://localhost");
+
+  let question: string | null;
+  if (req.method === "GET") {
+    question = url.searchParams.get("q");
+  } else if (req.method === "POST") {
+    try {
+      const body = (await readJsonBody(req)) as { question?: string };
+      question = body.question ?? null;
+    } catch {
+      sendJson(res, 400, { error: "invalid JSON body" });
+      return;
+    }
+  } else {
+    sendJson(res, 405, { error: "method not allowed" });
+    return;
+  }
+
+  const raw = await readFile(TRANSCRIPT_PATH, "utf8");
+  const transcript = JSON.parse(raw) as TranscriptItem[];
+
+  const parsed = parseQaInput({
+    t: url.searchParams.get("t"),
+    question,
+    transcript,
+  });
+  if (!parsed.ok) {
+    sendJson(res, parsed.status, { error: parsed.error });
+    return;
+  }
+
+  res.statusCode = 200;
+  res.setHeader("content-type", "text/event-stream");
+  res.setHeader("cache-control", "no-cache");
+  res.setHeader("connection", "keep-alive");
+  // Disable proxy buffering (nginx etc).
+  res.setHeader("x-accel-buffering", "no");
+  res.flushHeaders?.();
+
+  try {
+    for await (const delta of streamAnswer(parsed)) {
+      writeSseEvent(res, { delta });
+    }
+    writeSseEvent(res, "[DONE]", "done");
+  } catch (err) {
+    writeSseEvent(
+      res,
+      { error: err instanceof Error ? err.message : "internal error" },
+      "error",
+    );
+  } finally {
+    res.end();
+  }
+}
+
+export function qaApiPlugin(): Plugin {
+  return {
+    name: "qa-api",
+    configureServer(server) {
+      server.middlewares.use("/api/qa", (req, res, next) => {
+        handle(req, res).catch(next);
+      });
+    },
+  };
+}

--- a/apps/web/tsconfig.app.json
+++ b/apps/web/tsconfig.app.json
@@ -7,7 +7,6 @@
     "types": ["vite/client"],
     "skipLibCheck": true,
     "strictNullChecks": true,
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     },

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/apps/web/tsconfig.node.json
+++ b/apps/web/tsconfig.node.json
@@ -20,5 +20,5 @@
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "server/**/*"]
 }

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -3,6 +3,7 @@ import { tanstackRouter } from "@tanstack/router-plugin/vite";
 import react from "@vitejs/plugin-react";
 import path from "path";
 import { defineConfig } from "vite";
+import { qaApiPlugin } from "./server/qa-plugin";
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -13,6 +14,7 @@ export default defineConfig({
       autoCodeSplitting: true,
     }),
     react(),
+    qaApiPlugin(),
   ],
   resolve: {
     alias: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,12 +32,16 @@
       "name": "@spr26/web",
       "version": "0.0.0",
       "dependencies": {
+        "@hono/node-server": "^1.13.7",
+        "@spr26/ai-service": "*",
         "@tailwindcss/vite": "^4.2.2",
         "@tanstack/react-router": "^1.168.22",
+        "hono": "^4.9.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-icons": "^5.6.0",
         "tailwindcss": "^4.2.2",
+        "tsx": "^4.21.0",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -47,6 +51,84 @@
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.1",
         "vite": "^8.0.4"
+      }
+    },
+    "node_modules/@ai-sdk/anthropic": {
+      "version": "3.0.71",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.71.tgz",
+      "integrity": "sha512-bUWOzrzR0gJKJO/PLGMR4uH2dqEgqGhrsCV+sSpk4KtOEnUQlfjZI/F7BFlqSvVpFbjdgYRRLysAeEZpJ6S1lg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "3.0.104",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.104.tgz",
+      "integrity": "sha512-ZKX5n74io8VIRlhIMSLWVlvT3sXC8Z7cZ9GHuWBWZDVi96+62AIsWuLGvMfcBA1STYuSoDrp6rIziZmvrTq0TA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23",
+        "@vercel/oidc": "3.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/openai": {
+      "version": "3.0.53",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.53.tgz",
+      "integrity": "sha512-Wld+Rbc05KaUn08uBt06eEuwcgalcIFtIl32Yp+GxuZXUQwOb6YeAuq+C6da4ch6BurFoqEaLemJVwjBb7x+PQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
+      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.23.tgz",
+      "integrity": "sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.6"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -382,6 +464,422 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
@@ -617,6 +1115,18 @@
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -744,6 +1254,15 @@
       "peerDependencies": {
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/@oxc-project/types": {
@@ -1035,9 +1554,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@spr26/ai-service": {
+      "resolved": "packages/ai-service",
+      "link": true
+    },
     "node_modules/@spr26/web": {
       "resolved": "apps/web",
       "link": true
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
     },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.4",
@@ -1882,6 +2411,15 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@vercel/oidc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.1.tgz",
@@ -1929,6 +2467,24 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ai": {
+      "version": "6.0.168",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.168.tgz",
+      "integrity": "sha512-2HqCJuO+1V2aV7vfYs5LFEUfxbkGX+5oa54q/gCCTL7KLTdbxcCu5D7TdLA5kwsrs3Szgjah9q6D9tpjHM3hUQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "3.0.104",
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23",
+        "@opentelemetry/api": "1.9.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/ajv": {
@@ -2269,6 +2825,47 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -2576,6 +3173,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2709,6 +3315,18 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -2766,6 +3384,15 @@
       "license": "MIT",
       "dependencies": {
         "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.15",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
+      "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
       }
     },
     "node_modules/ignore": {
@@ -2885,6 +3512,12 @@
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -3605,6 +4238,15 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/rolldown": {
       "version": "1.0.0-rc.17",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
@@ -3813,6 +4455,25 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD",
       "optional": true
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -4087,6 +4748,15 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "packages/ai-service": {
+      "name": "@spr26/ai-service",
+      "version": "0.0.0",
+      "dependencies": {
+        "@ai-sdk/anthropic": "^3.0.0",
+        "@ai-sdk/openai": "^3.0.0",
+        "ai": "^6.0.0"
       }
     }
   }

--- a/packages/ai-service/.env.example
+++ b/packages/ai-service/.env.example
@@ -1,0 +1,4 @@
+# LLM provider keys. The QA endpoint uses ANTHROPIC_API_KEY if set
+# (claude-opus-4-7), otherwise OPENAI_API_KEY (gpt-5.5). Set at least one.
+ANTHROPIC_API_KEY=
+OPENAI_API_KEY=

--- a/packages/ai-service/.gitignore
+++ b/packages/ai-service/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.env
+.env.local

--- a/packages/ai-service/package.json
+++ b/packages/ai-service/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@spr26/ai-service",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "build": "tsc -b"
+  },
+  "dependencies": {
+    "@ai-sdk/anthropic": "^3.0.0",
+    "@ai-sdk/openai": "^3.0.0",
+    "ai": "^6.0.0"
+  }
+}

--- a/packages/ai-service/src/handler.ts
+++ b/packages/ai-service/src/handler.ts
@@ -1,0 +1,35 @@
+import type { TranscriptItem } from "./qa.ts";
+
+export interface QaRawInput {
+  t: string | null;
+  question: string | null;
+  transcript: TranscriptItem[];
+}
+
+export type QaParseResult =
+  | {
+      ok: true;
+      uptoSeconds: number;
+      question: string;
+      transcript: TranscriptItem[];
+    }
+  | { ok: false; status: 400; error: string };
+
+export function parseQaInput(input: QaRawInput): QaParseResult {
+  if (input.t === null) {
+    return { ok: false, status: 400, error: "missing t query param" };
+  }
+  const uptoSeconds = Number(input.t);
+  if (!Number.isFinite(uptoSeconds)) {
+    return { ok: false, status: 400, error: "t must be a number (seconds)" };
+  }
+  if (!input.question) {
+    return { ok: false, status: 400, error: "missing question" };
+  }
+  return {
+    ok: true,
+    uptoSeconds,
+    question: input.question,
+    transcript: input.transcript,
+  };
+}

--- a/packages/ai-service/src/index.ts
+++ b/packages/ai-service/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./qa.ts";
+export * from "./handler.ts";

--- a/packages/ai-service/src/qa.ts
+++ b/packages/ai-service/src/qa.ts
@@ -1,0 +1,72 @@
+import { anthropic } from "@ai-sdk/anthropic";
+import { openai } from "@ai-sdk/openai";
+import { streamText, type LanguageModel } from "ai";
+
+export const ANTHROPIC_MODEL = "claude-opus-4-7";
+export const OPENAI_MODEL = "gpt-5.5";
+
+function selectModel(): LanguageModel {
+  if (process.env.ANTHROPIC_API_KEY) return anthropic(ANTHROPIC_MODEL);
+  if (process.env.OPENAI_API_KEY) return openai(OPENAI_MODEL);
+  throw new Error(
+    "set ANTHROPIC_API_KEY or OPENAI_API_KEY to use the QA endpoint",
+  );
+}
+
+export interface TranscriptItem {
+  timestamp: string;
+  content: string;
+}
+
+export function parseTimestamp(ts: string): number {
+  const parts = ts.split(":").map((p) => Number.parseInt(p, 10));
+  if (parts.some(Number.isNaN)) {
+    throw new Error(`invalid timestamp: ${ts}`);
+  }
+  if (parts.length === 2) return parts[0] * 60 + parts[1];
+  if (parts.length === 3) return parts[0] * 3600 + parts[1] * 60 + parts[2];
+  throw new Error(`invalid timestamp: ${ts}`);
+}
+
+export interface AnswerQuestionInput {
+  transcript: TranscriptItem[];
+  /** include only transcript lines whose timestamp (in seconds) is < this value */
+  uptoSeconds: number;
+  question: string;
+}
+
+const SYSTEM_PROMPT =
+  "You are a helpful study assistant. Answer the student's question using only the lecture transcript provided. If the answer is not in the transcript, say you don't know. Keep answers concise and reference timestamps when relevant.";
+
+function buildPrompt({
+  transcript,
+  uptoSeconds,
+  question,
+}: AnswerQuestionInput) {
+  const visible = transcript.filter(
+    (line) => parseTimestamp(line.timestamp) < uptoSeconds,
+  );
+  const transcriptText = visible
+    .map((l) => `[${l.timestamp}] ${l.content}`)
+    .join("\n");
+  return `<transcript>
+${transcriptText}
+</transcript>
+
+Question: ${question}`;
+}
+
+/** Streams text deltas as they arrive from the model. */
+export async function* streamAnswer(
+  input: AnswerQuestionInput,
+): AsyncIterable<string> {
+  const result = streamText({
+    model: selectModel(),
+    system: SYSTEM_PROMPT,
+    prompt: buildPrompt(input),
+    temperature: 0,
+  });
+  for await (const delta of result.textStream) {
+    yield delta;
+  }
+}

--- a/packages/ai-service/tsconfig.json
+++ b/packages/ai-service/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.tsbuildinfo",
+    "target": "es2023",
+    "lib": ["ES2023"],
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "types": ["node"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "composite": true,
+    "declaration": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "moduleDetection": "force",
+    "verbatimModuleSyntax": true,
+    "erasableSyntaxOnly": true,
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src"]
+}

--- a/runbooks/qa-api.md
+++ b/runbooks/qa-api.md
@@ -1,0 +1,184 @@
+# QA API
+
+A streaming endpoint that answers questions about the lecture transcript using
+an LLM. Retrieval is intentionally trivial: the handler filters the transcript
+to the lines whose timestamp is **before** `t` (the current playback position)
+and puts those lines straight in the prompt. No DB, no embeddings.
+
+The endpoint streams tokens back over **Server-Sent Events**.
+
+## Architecture
+
+```
+apps/web/                              packages/ai-service/
+├── server/                            └── src/
+│   ├── qa-plugin.ts  (vite dev mw)        ├── qa.ts       streamAnswer()
+│   └── index.ts      (hono prod)          ├── handler.ts  parseQaInput()
+└── src/data/transcript.json               └── index.ts
+```
+
+`@spr26/ai-service` is framework-agnostic:
+
+- `streamAnswer({ transcript, uptoSeconds, question })` →
+  `AsyncIterable<string>`. Each yielded string is a token delta from the model.
+- `parseQaInput({ t, question, transcript })` → tagged union; validates the
+  request and either returns `{ ok: true, ... }` ready for `streamAnswer`, or
+  `{ ok: false, status: 400, error: "..." }` for the adapter to send back.
+- `parseTimestamp("12:34")` / `parseTimestamp("1:02:03")` — `mm:ss` or
+  `h:mm:ss` → seconds.
+
+The Vite middleware (`server/qa-plugin.ts`) and the Hono server
+(`server/index.ts`) are thin adapters: parse the HTTP request, load
+`transcript.json` from disk, validate via `parseQaInput`, then iterate
+`streamAnswer` and write SSE frames.
+
+## Environment variables
+
+The model is picked at request time based on which key is set:
+
+| Var                 | Model used        |
+| ------------------- | ----------------- |
+| `ANTHROPIC_API_KEY` | `claude-opus-4-7` |
+| `OPENAI_API_KEY`    | `gpt-5.5`         |
+
+Anthropic wins if both are set. The stream emits an `error` event with a clear
+message if neither is set.
+
+`PORT` controls the production server's listen port (default `3000`).
+
+## API contract
+
+`GET /api/qa?t=<seconds>&q=<question>`
+`POST /api/qa?t=<seconds>` with body `{ "question": "..." }`
+
+`t` is required and must be a finite number (seconds). Lines whose timestamp is
+strictly less than `t` are included in the prompt. POST is preferred for
+non-trivial questions (no URL-length limit, easier to escape).
+
+**Validation errors** (returned as plain JSON, not SSE):
+
+- `400` → `{ "error": "missing t query param" | "t must be a number (seconds)" | "missing question" | "invalid JSON body" }`
+- `405` → `{ "error": "method not allowed" }`
+
+**Success** (`200`, `Content-Type: text/event-stream`):
+
+```
+data: {"delta":"The"}
+
+data: {"delta":" professor"}
+
+data: {"delta":" mentions..."}
+
+event: done
+data: "[DONE]"
+```
+
+**Streaming errors** (mid-stream model/auth failure):
+
+```
+event: error
+data: {"error":"<message>"}
+```
+
+The connection then closes. Clients should reconnect or surface the error.
+
+## Running it
+
+### Dev
+
+```bash
+ANTHROPIC_API_KEY=… npm run dev      # from repo root, runs vite at :5173
+curl -N 'http://localhost:5173/api/qa?t=300&q=who+is+teaching+today'
+```
+
+`-N` (no buffering) is important — `curl` otherwise waits for the connection to
+close before printing anything. The Vite dev server mounts the QA middleware
+before the SPA, so the same origin serves both.
+
+### Production
+
+```bash
+npm run build -w @spr26/web                       # vite build → apps/web/dist/
+ANTHROPIC_API_KEY=… npm run start -w @spr26/web   # hono on :3000
+```
+
+The Hono server serves `apps/web/dist/` as static, falls back to `index.html`
+for SPA routes, and mounts the QA endpoint at `/api/qa`. Run it from anywhere —
+it `chdir`s to its own directory at startup.
+
+## Calling it from the React app
+
+`EventSource` is the path-of-least-resistance for SSE, but it's GET-only and
+won't carry a JSON body. For long questions use `fetch` + a manual SSE parser
+on the response body:
+
+```ts
+export async function askStream(
+  question: string,
+  currentSeconds: number,
+  onDelta: (chunk: string) => void,
+): Promise<void> {
+  const res = await fetch(`/api/qa?t=${currentSeconds}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ question }),
+  });
+  if (!res.ok) throw new Error((await res.json()).error);
+  if (!res.body) throw new Error("no response body");
+
+  const reader = res.body.pipeThrough(new TextDecoderStream()).getReader();
+  let buffer = "";
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) return;
+    buffer += value;
+
+    // SSE frames are separated by a blank line.
+    let idx;
+    while ((idx = buffer.indexOf("\n\n")) !== -1) {
+      const frame = buffer.slice(0, idx);
+      buffer = buffer.slice(idx + 2);
+
+      const lines = frame.split("\n");
+      const event = lines.find((l) => l.startsWith("event: "))?.slice(7);
+      const data = lines.find((l) => l.startsWith("data: "))?.slice(6);
+      if (!data) continue;
+
+      if (event === "done") return;
+      if (event === "error") throw new Error(JSON.parse(data).error);
+      const parsed = JSON.parse(data) as { delta?: string };
+      if (parsed.delta) onDelta(parsed.delta);
+    }
+  }
+}
+```
+
+`currentSeconds` is the video player's current time. Pass it raw — the API
+expects seconds, the same unit `parseTimestamp` returns.
+
+In a React component, accumulate deltas into local state and abort the request
+on unmount with `AbortController`.
+
+## Adding new endpoints
+
+1. Put framework-agnostic logic in `packages/ai-service/src/<name>.ts` and
+   export it from `index.ts`. Anything that touches `process.env`, the LLM,
+   or pure data transforms goes here. For streaming endpoints, expose an
+   `AsyncIterable<T>` rather than the raw ai-sdk result — keeps the surface
+   small and avoids leaking complex generic types.
+2. Add an adapter in **both** `apps/web/server/qa-plugin.ts` (dev mw) **and**
+   `apps/web/server/index.ts` (Hono). Keep them ~30 lines each: parse request
+   → call the shared logic → write the response.
+3. If the new handler reads files at runtime, resolve paths from
+   `import.meta.dirname` (dev plugin) or the `APP_ROOT` constant (Hono) — never
+   from `process.cwd()`, since dev and prod run from different directories.
+
+## Switching the data source
+
+Right now both adapters `readFile(transcript.json)` on every request. Cheap
+because the file is small (~30KB), but if you swap to a DB or remote fetch:
+
+- Don't push that into `@spr26/ai-service` — keep it pure.
+- Replace the `readFile` + `JSON.parse` in each adapter with the new loader.
+- Cache at the adapter layer if you need to (a module-level `let cached` is
+  fine for a single transcript; reach for an LRU once there are many).


### PR DESCRIPTION
## Summary
- New `@spr26/ai-service` module (`streamAnswer`, `parseQaInput`) — filters the transcript to lines before `t` seconds and streams Anthropic (`claude-opus-4-7`) or OpenAI (`gpt-5.5`) token deltas as an `AsyncIterable<string>`. Provider picked at request time from `ANTHROPIC_API_KEY` / `OPENAI_API_KEY`.
- Two thin HTTP adapters: a Vite dev middleware at `/api/qa` (so dev + SPA share an origin) and a Hono production server (`apps/web/server/index.ts`) that also serves `dist/`. Both emit Server-Sent Events.
- `runbooks/qa-api.md` covers the contract, env vars, dev/prod commands, and a `fetch`-based SSE client component.
- Drops the prior db/drizzle/embeddings scaffold from ai-service since the QA flow doesn't need it; old migration runbook removed.

## Test plan
- [x] `npm run lint` clean (pre-existing react-refresh warnings only)
- [x] `tsc -b` clean across both packages
- [x] Dev server hit: `POST /api/qa?t=300` with `{"question":"who is teaching today and why?"}` streams a correct answer citing transcript timestamps `[0:06–0:50]`, `[0:50–1:03]`
- [x] Cutoff filter: `t=10` constrains the model to the single `0:06` line
- [x] Validation: missing `t` and missing `question` return JSON `400`s, not SSE
- [ ] Prod path verified locally: `npm run build -w @spr26/web && ANTHROPIC_API_KEY=… npm run start -w @spr26/web`

🤖 Generated with [Claude Code](https://claude.com/claude-code)