### PR TITLE
Live transcription + RAG with citations + instructor advanced tools

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -10,3 +10,6 @@ DATABASE_URL=
 # LLM providers — set at least one.
 ANTHROPIC_API_KEY=
 OPENAI_API_KEY=
+
+# Groq — Whisper-large-v3 transcription via OpenAI-compatible API.
+GROQ_API_KEY=

--- a/apps/web/app/api/chunk/route.ts
+++ b/apps/web/app/api/chunk/route.ts
@@ -1,0 +1,38 @@
+import { backfillChunkEmbeddings, buildPendingChunks } from "@/lib/chunker";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+// Called directly with a session id to build chunks for that session, OR
+// hit with no body by the Vercel cron as a backfill safety net.
+export async function POST(req: Request) {
+  let body: { sessionId?: string } = {};
+  try {
+    body = (await req.json()) as { sessionId?: string };
+  } catch {
+    /* empty body OK */
+  }
+
+  try {
+    if (!body.sessionId) {
+      const embedded = await backfillChunkEmbeddings();
+      return Response.json({ ...embedded });
+    }
+    const built = await buildPendingChunks(body.sessionId);
+    return Response.json(built);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "chunk failed";
+    return Response.json({ error: message }, { status: 500 });
+  }
+}
+
+export async function GET() {
+  try {
+    const embedded = await backfillChunkEmbeddings();
+    return Response.json(embedded);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "chunk failed";
+    return Response.json({ error: message }, { status: 500 });
+  }
+}

--- a/apps/web/app/api/embed/route.ts
+++ b/apps/web/app/api/embed/route.ts
@@ -1,43 +1,47 @@
 import { db } from "@/lib/db";
 import { transcriptItems } from "@spr26/db";
+import { openai } from "@ai-sdk/openai";
+import { embedMany } from "ai";
 import { eq, isNull } from "drizzle-orm";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-// Computes embeddings for transcript_items rows and writes them back.
-// Caller passes a specific id, or omits to backfill up to 50 NULL rows.
-// embedMany call is stubbed — wire `ai` + `@ai-sdk/openai` to enable.
-export async function POST(req: Request) {
-  let payload: { transcriptItemId?: string } = {};
-  try {
-    payload = (await req.json()) as { transcriptItemId?: string };
-  } catch {
-    /* allow empty body */
-  }
+// 1536-dim, matches vector(1536). L2-normalised, so cosine ≈ dot product,
+// which is what the HNSW vector_cosine_ops index expects.
+const EMBED_MODEL = "text-embedding-3-small";
 
-  const where = payload.transcriptItemId
-    ? eq(transcriptItems.id, payload.transcriptItemId)
+async function embedWithRetry(values: string[]): Promise<number[][]> {
+  let lastErr: unknown;
+  for (let attempt = 0; attempt < 3; attempt++) {
+    if (attempt > 0) await new Promise((r) => setTimeout(r, 300 * attempt));
+    try {
+      const { embeddings } = await embedMany({
+        model: openai.embedding(EMBED_MODEL),
+        values,
+      });
+      return embeddings;
+    } catch (err) {
+      lastErr = err;
+    }
+  }
+  throw lastErr ?? new Error("embedMany failed");
+}
+
+async function processBatch(transcriptItemId?: string) {
+  const where = transcriptItemId
+    ? eq(transcriptItems.id, transcriptItemId)
     : isNull(transcriptItems.embedding);
 
   const rows = await db()
     .select({ id: transcriptItems.id, content: transcriptItems.content })
     .from(transcriptItems)
     .where(where)
-    .limit(payload.transcriptItemId ? 1 : 50);
+    .limit(transcriptItemId ? 1 : 50);
 
-  if (rows.length === 0) return Response.json({ embedded: 0 });
+  if (rows.length === 0) return 0;
 
-  // TODO(amrit): replace stub with:
-  //   import { embedMany } from "ai";
-  //   import { openai } from "@ai-sdk/openai";
-  //   const { embeddings } = await embedMany({
-  //     model: openai.embedding("text-embedding-3-small"),
-  //     values: rows.map((r) => r.content),
-  //   });
-  const embeddings: number[][] = rows.map(() =>
-    Array.from({ length: 1536 }, () => 0),
-  );
+  const embeddings = await embedWithRetry(rows.map((r) => r.content));
 
   for (let i = 0; i < rows.length; i++) {
     await db()
@@ -46,5 +50,25 @@ export async function POST(req: Request) {
       .where(eq(transcriptItems.id, rows[i].id));
   }
 
-  return Response.json({ embedded: rows.length });
+  return rows.length;
+}
+
+// Called directly by /api/transcribe with a specific id for low-latency
+// embedding right after insert.
+export async function POST(req: Request) {
+  let payload: { transcriptItemId?: string } = {};
+  try {
+    payload = (await req.json()) as { transcriptItemId?: string };
+  } catch {
+    /* empty body OK */
+  }
+  const embedded = await processBatch(payload.transcriptItemId);
+  return Response.json({ embedded });
+}
+
+// Called by Vercel Cron every minute. Backfills any row with NULL embedding
+// (transcribe-side handoff drops, transient OpenAI failures, etc.).
+export async function GET() {
+  const embedded = await processBatch();
+  return Response.json({ embedded });
 }

--- a/apps/web/app/api/qa/route.ts
+++ b/apps/web/app/api/qa/route.ts
@@ -1,45 +1,268 @@
-import { parseQaInput, streamAnswer } from "@spr26/ai-service";
-import transcriptJson from "@/data/transcript.json";
+import { db } from "@/lib/db";
+import {
+  courseMaterialChunks,
+  courseMaterials,
+  sessions,
+  transcriptItems,
+} from "@spr26/db";
+import { anthropic } from "@ai-sdk/anthropic";
+import { openai } from "@ai-sdk/openai";
+import {
+  embed,
+  stepCountIs,
+  streamText,
+  tool,
+  type LanguageModel,
+} from "ai";
+import { and, asc, eq, isNotNull, sql } from "drizzle-orm";
+import { z } from "zod";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-type TranscriptRow = { timestamp: string; content: string };
-const transcript = transcriptJson as TranscriptRow[];
+const ANTHROPIC_MODEL = "claude-opus-4-7";
+const OPENAI_MODEL = "gpt-5.5";
+const EMBED_MODEL = "text-embedding-3-small";
+
+const SYSTEM_PROMPT = `You are a study assistant for InLecture, embedded in a live lecture session.
+
+The full transcript of today's lecture is provided inline below, with [HH:MM] timestamps prefixing each line. Answer the student's question using this transcript.
+
+CITATION RULES (strict):
+- When you reference something from the lecture transcript, cite the moment inline using its [HH:MM] timestamp from the transcript. Example: "The professor introduced convolutions [02:13] and walked through the dice example [05:08]."
+- If you call search_course_materials, the tool returns numbered results like [M1], [M2]. Cite them in the answer using those exact labels.
+- Never invent citations. Only cite timestamps or material labels that actually appear in your inputs.
+
+If the answer isn't in the transcript or in returned materials, say so plainly. Keep answers concise.`;
+
+interface MaterialCitation {
+  n: number;
+  materialId: string;
+  materialTitle: string;
+  chunkId: string;
+  pageNumber: number | null;
+  preview: string;
+}
+
+function selectModel(): LanguageModel {
+  if (process.env.ANTHROPIC_API_KEY) return anthropic(ANTHROPIC_MODEL);
+  if (process.env.OPENAI_API_KEY) return openai(OPENAI_MODEL);
+  throw new Error("set ANTHROPIC_API_KEY or OPENAI_API_KEY");
+}
+
+function formatTs(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
+}
 
 async function handle(req: Request) {
-  const url = new URL(req.url);
-  let question: string | null;
+  let question: string | undefined;
+  let sessionId: string | undefined;
+
   if (req.method === "GET") {
-    question = url.searchParams.get("q");
+    const url = new URL(req.url);
+    question = url.searchParams.get("q") ?? undefined;
+    sessionId = url.searchParams.get("sessionId") ?? undefined;
   } else {
     try {
-      const body = (await req.json()) as { question?: string };
-      question = body.question ?? null;
+      const body = (await req.json()) as {
+        question?: string;
+        sessionId?: string;
+      };
+      question = body.question;
+      sessionId = body.sessionId;
     } catch {
       return Response.json({ error: "invalid JSON body" }, { status: 400 });
     }
   }
 
-  const parsed = parseQaInput({
-    t: url.searchParams.get("t"),
-    f: url.searchParams.get("f"),
-    question,
-    transcript,
-  });
-  if (!parsed.ok) {
-    return Response.json({ error: parsed.error }, { status: parsed.status });
+  if (!question?.trim()) {
+    return Response.json({ error: "question is required" }, { status: 400 });
+  }
+  if (!sessionId) {
+    return Response.json({ error: "sessionId is required" }, { status: 400 });
   }
 
+  // Resolve courseId from sessionId so we know where to look for materials.
+  const [sessionRow] = await db()
+    .select({ courseId: sessions.courseId })
+    .from(sessions)
+    .where(eq(sessions.id, sessionId));
+  if (!sessionRow) {
+    return Response.json({ error: "session not found" }, { status: 404 });
+  }
+  const courseId = sessionRow.courseId;
+
+  // Pull the entire transcript inline. For a typical lecture (~50min) this
+  // is ~10k tokens — well within Claude Opus's window.
+  const transcript = await db()
+    .select({
+      sequence: transcriptItems.sequence,
+      timestampSeconds: transcriptItems.timestampSeconds,
+      content: transcriptItems.content,
+    })
+    .from(transcriptItems)
+    .where(eq(transcriptItems.sessionId, sessionId))
+    .orderBy(asc(transcriptItems.sequence));
+
+  const transcriptBlock =
+    transcript.length === 0
+      ? "<transcript>\n(no transcript captured yet)\n</transcript>"
+      : `<transcript>\n${transcript
+          .map((r) => `[${formatTs(r.timestampSeconds)}] ${r.content}`)
+          .join("\n")}\n</transcript>`;
+
+  const materialCitations: MaterialCitation[] = [];
+
+  // Optional tool — searches uploaded course materials via pgvector. Returns
+  // empty when nothing's been uploaded for this course yet.
+  const searchCourseMaterials = tool({
+    description:
+      "Semantic search over course materials uploaded for this class (slides, notes, readings). Use when the question references content that may live in those materials rather than today's transcript. Returns numbered [M1], [M2]... results.",
+    inputSchema: z.object({
+      query: z.string().describe("Focused search query."),
+      k: z.number().int().min(1).max(8).default(4),
+    }),
+    execute: async ({ query, k }) => {
+      if (!process.env.OPENAI_API_KEY) {
+        return { results: [], note: "OPENAI_API_KEY not set" };
+      }
+      const { embedding } = await embed({
+        model: openai.embedding(EMBED_MODEL),
+        value: query,
+      });
+      const vec = `[${embedding.join(",")}]`;
+
+      const hits = await db()
+        .select({
+          chunkId: courseMaterialChunks.id,
+          materialId: courseMaterialChunks.courseMaterialId,
+          chunkIndex: courseMaterialChunks.chunkIndex,
+          content: courseMaterialChunks.content,
+          pageNumber: courseMaterialChunks.pageNumber,
+          materialTitle: courseMaterials.title,
+        })
+        .from(courseMaterialChunks)
+        .innerJoin(
+          courseMaterials,
+          eq(courseMaterialChunks.courseMaterialId, courseMaterials.id),
+        )
+        .where(
+          and(
+            eq(courseMaterials.courseId, courseId),
+            isNotNull(courseMaterialChunks.embedding),
+          ),
+        )
+        .orderBy(sql`${courseMaterialChunks.embedding} <=> ${vec}::vector`)
+        .limit(k);
+
+      if (hits.length === 0) {
+        return {
+          results: [],
+          note: "No course materials uploaded yet for this course.",
+        };
+      }
+
+      const results = hits.map((h) => {
+        const n = materialCitations.length + 1;
+        materialCitations.push({
+          n,
+          materialId: h.materialId,
+          materialTitle: h.materialTitle,
+          chunkId: h.chunkId,
+          pageNumber: h.pageNumber,
+          preview: h.content.slice(0, 200),
+        });
+        return {
+          label: `[M${n}]`,
+          title: h.materialTitle,
+          page: h.pageNumber,
+          content: h.content,
+        };
+      });
+      return { results };
+    },
+  });
+
+  const model = selectModel();
+  const result = streamText({
+    model,
+    system: SYSTEM_PROMPT,
+    prompt: `${transcriptBlock}\n\nStudent question: ${question}`,
+    temperature: 0,
+    tools: { search_course_materials: searchCourseMaterials },
+    stopWhen: stepCountIs(4),
+  });
+
   const encoder = new TextEncoder();
+
   const stream = new ReadableStream<Uint8Array>({
     async start(controller) {
       try {
-        for await (const delta of streamAnswer(parsed)) {
-          controller.enqueue(
-            encoder.encode(`data: ${JSON.stringify({ delta })}\n\n`),
-          );
+        for await (const part of result.fullStream) {
+          if (part.type === "text-delta") {
+            const delta =
+              (part as { textDelta?: string; text?: string }).textDelta ??
+              (part as { text?: string }).text ??
+              "";
+            if (!delta) continue;
+            controller.enqueue(
+              encoder.encode(`data: ${JSON.stringify({ delta })}\n\n`),
+            );
+          } else if (part.type === "tool-call") {
+            const p = part as unknown as {
+              toolCallId: string;
+              toolName: string;
+              args?: Record<string, unknown>;
+              input?: Record<string, unknown>;
+            };
+            controller.enqueue(
+              encoder.encode(
+                `event: tool_call\ndata: ${JSON.stringify({
+                  id: p.toolCallId,
+                  name: p.toolName,
+                  args: p.args ?? p.input ?? {},
+                })}\n\n`,
+              ),
+            );
+          } else if (part.type === "tool-result") {
+            const p = part as unknown as {
+              toolCallId: string;
+              toolName: string;
+              output?: { results?: unknown[] };
+              result?: { results?: unknown[] };
+            };
+            const out = p.output ?? p.result ?? {};
+            const count = Array.isArray(out.results) ? out.results.length : 0;
+            controller.enqueue(
+              encoder.encode(
+                `event: tool_result\ndata: ${JSON.stringify({
+                  id: p.toolCallId,
+                  name: p.toolName,
+                  count,
+                })}\n\n`,
+              ),
+            );
+          } else if (part.type === "error") {
+            const p = part as unknown as { error?: unknown };
+            const msg =
+              p.error instanceof Error ? p.error.message : String(p.error);
+            controller.enqueue(
+              encoder.encode(
+                `event: error\ndata: ${JSON.stringify({ error: msg })}\n\n`,
+              ),
+            );
+          }
         }
+
+        controller.enqueue(
+          encoder.encode(
+            `event: citations\ndata: ${JSON.stringify({
+              materials: materialCitations,
+            })}\n\n`,
+          ),
+        );
         controller.enqueue(encoder.encode(`event: done\ndata: "[DONE]"\n\n`));
       } catch (err) {
         const msg = err instanceof Error ? err.message : "internal error";

--- a/apps/web/app/api/sessions/load-sample/route.ts
+++ b/apps/web/app/api/sessions/load-sample/route.ts
@@ -1,0 +1,60 @@
+import { db } from "@/lib/db";
+import { transcriptItems } from "@spr26/db";
+import { eq } from "drizzle-orm";
+import seededTranscript from "@/data/transcript.json";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+function parseTs(ts: string): number {
+  const parts = ts.split(":").map((p) => Number.parseInt(p, 10));
+  if (parts.some(Number.isNaN)) return 0;
+  if (parts.length === 2) return parts[0] * 60 + parts[1];
+  if (parts.length === 3) return parts[0] * 3600 + parts[1] * 60 + parts[2];
+  return 0;
+}
+
+// Bypasses Whisper for demos: takes the bundled lecture transcript JSON and
+// loads it into transcript_items for the given session, then embeds everything
+// in one shot so RAG works immediately.
+export async function POST(req: Request) {
+  let body: { sessionId?: string };
+  try {
+    body = (await req.json()) as { sessionId?: string };
+  } catch {
+    return Response.json({ error: "invalid JSON body" }, { status: 400 });
+  }
+  const sessionId = body.sessionId;
+  if (!sessionId) {
+    return Response.json({ error: "sessionId is required" }, { status: 400 });
+  }
+
+  const items = seededTranscript as Array<{
+    timestamp: string;
+    content: string;
+  }>;
+
+  const rows = items
+    .filter((it) => it.content.trim().length > 0)
+    .map((it, index) => ({
+      sessionId,
+      sequence: index,
+      timestampSeconds: parseTs(it.timestamp),
+      content: it.content.trim(),
+    }));
+
+  if (rows.length === 0) return Response.json({ inserted: 0 });
+
+  // Wipe any existing rows for this session so the sample is the only source.
+  await db()
+    .delete(transcriptItems)
+    .where(eq(transcriptItems.sessionId, sessionId));
+
+  const inserted = await db()
+    .insert(transcriptItems)
+    .values(rows)
+    .returning({ id: transcriptItems.id });
+
+  return Response.json({ inserted: inserted.length });
+}

--- a/apps/web/app/api/sessions/reset/route.ts
+++ b/apps/web/app/api/sessions/reset/route.ts
@@ -1,0 +1,28 @@
+import { db } from "@/lib/db";
+import { transcriptItems } from "@spr26/db";
+import { eq } from "drizzle-orm";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// Clears all transcript_items for a session — used by the instructor "Reset"
+// button to wipe demo state and start over.
+export async function POST(req: Request) {
+  let body: { sessionId?: string };
+  try {
+    body = (await req.json()) as { sessionId?: string };
+  } catch {
+    return Response.json({ error: "invalid JSON body" }, { status: 400 });
+  }
+  const sessionId = body.sessionId;
+  if (!sessionId) {
+    return Response.json({ error: "sessionId is required" }, { status: 400 });
+  }
+
+  const deleted = await db()
+    .delete(transcriptItems)
+    .where(eq(transcriptItems.sessionId, sessionId))
+    .returning({ id: transcriptItems.id });
+
+  return Response.json({ deleted: deleted.length });
+}

--- a/apps/web/app/api/transcribe/route.ts
+++ b/apps/web/app/api/transcribe/route.ts
@@ -1,14 +1,67 @@
 import { db } from "@/lib/db";
 import { transcriptItems } from "@spr26/db";
+import { eq, sql } from "drizzle-orm";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-// Receives a single ~8s audio chunk from the instructor's RecordButton, runs
-// speech-to-text, and inserts a transcript_items row. Supabase Realtime
-// publication on transcript_items pushes the row to subscribed clients.
-//
-// Whisper integration is stubbed — wire OPENAI_API_KEY then drop in the call.
+const GROQ_TRANSCRIBE_URL =
+  "https://api.groq.com/openai/v1/audio/transcriptions";
+// whisper-large-v3-turbo: ~3x faster than v3 with similar accuracy on short
+// clips. Both are on Groq's free tier.
+const GROQ_MODEL = "whisper-large-v3-turbo";
+const CHUNK_SECONDS = 10;
+
+interface GroqResponse {
+  text: string;
+}
+
+async function transcribeWithGroq(audio: Blob): Promise<string> {
+  const apiKey = process.env.GROQ_API_KEY;
+  if (!apiKey) throw new Error("GROQ_API_KEY is not set");
+
+  const fd = new FormData();
+  fd.append("file", audio, "chunk.webm");
+  fd.append("model", GROQ_MODEL);
+  fd.append("response_format", "json");
+  fd.append("temperature", "0");
+  fd.append("language", "en");
+
+  // Two retries with light backoff for transient 429/5xx from Groq.
+  let lastErr: unknown;
+  for (let attempt = 0; attempt < 3; attempt++) {
+    if (attempt > 0) await new Promise((r) => setTimeout(r, 250 * attempt));
+    const res = await fetch(GROQ_TRANSCRIBE_URL, {
+      method: "POST",
+      headers: { authorization: `Bearer ${apiKey}` },
+      body: fd,
+    });
+    if (res.ok) {
+      const data = (await res.json()) as GroqResponse;
+      return data.text.trim();
+    }
+    if (res.status !== 429 && res.status < 500) {
+      const text = await res.text().catch(() => "");
+      throw new Error(`Groq transcribe ${res.status}: ${text}`);
+    }
+    lastErr = new Error(`Groq transcribe ${res.status}`);
+  }
+  throw lastErr ?? new Error("Groq transcribe failed");
+}
+
+// Whisper boilerplate on silence/noise — drop so transcripts don't fill with
+// "you" / "Thanks for watching."
+const NOISE_PATTERNS = [
+  /^you$/i,
+  /^thank you\.?$/i,
+  /^thanks for watching\.?$/i,
+  /^\.+$/,
+];
+
+function isNoise(text: string): boolean {
+  return text.length === 0 || NOISE_PATTERNS.some((p) => p.test(text));
+}
+
 export async function POST(req: Request) {
   const form = await req.formData();
   const sessionId = form.get("sessionId");
@@ -21,49 +74,42 @@ export async function POST(req: Request) {
       { status: 400 },
     );
   }
-  const sequence = Number.parseInt(sequenceRaw, 10);
-  if (!Number.isFinite(sequence)) {
-    return Response.json(
-      { error: "sequence must be an integer" },
-      { status: 400 },
-    );
-  }
   if (!(audio instanceof Blob)) {
     return Response.json({ error: "audio file required" }, { status: 400 });
   }
+  // Tiny payloads are usually flushes from MediaRecorder.stop() that contain
+  // no audible content; Whisper rejects them with 400.
+  if (audio.size < 2_000) {
+    return Response.json({ skipped: true, reason: "too_small" });
+  }
 
-  // TODO(amrit): swap stub for real Whisper call:
-  //   const fd = new FormData();
-  //   fd.append("file", audio, "chunk.webm");
-  //   fd.append("model", "whisper-1");
-  //   const r = await fetch("https://api.openai.com/v1/audio/transcriptions", {
-  //     method: "POST",
-  //     headers: { authorization: `Bearer ${process.env.OPENAI_API_KEY}` },
-  //     body: fd,
-  //   });
-  //   const { text } = await r.json();
-  const text = `[stub transcript for chunk ${sequence} — wire Whisper to replace]`;
+  let text: string;
+  try {
+    text = await transcribeWithGroq(audio);
+  } catch (err) {
+    return Response.json(
+      { error: err instanceof Error ? err.message : "transcription failed" },
+      { status: 502 },
+    );
+  }
 
-  // Approximate timestamp via sequence × chunk duration (8s); thread a real
-  // wall-clock offset through later.
-  const timestampSeconds = sequence * 8;
+  if (isNoise(text)) {
+    return Response.json({ skipped: true, reason: "silence_or_noise" });
+  }
+
+  // Pick the next sequence server-side so a restarted recording (client
+  // seqRef resets to 0) doesn't collide with rows already in the session.
+  const [{ next }] = await db()
+    .select({ next: sql<number>`COALESCE(MAX(${transcriptItems.sequence}) + 1, 0)::int` })
+    .from(transcriptItems)
+    .where(eq(transcriptItems.sessionId, sessionId));
+
+  const timestampSeconds = next * CHUNK_SECONDS;
 
   const [row] = await db()
     .insert(transcriptItems)
-    .values({
-      sessionId,
-      sequence,
-      timestampSeconds,
-      content: text,
-    })
+    .values({ sessionId, sequence: next, timestampSeconds, content: text })
     .returning({ id: transcriptItems.id });
 
-  // Fire-and-forget the embedding job. Don't block transcript broadcast.
-  void fetch(new URL("/api/embed", req.url), {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ transcriptItemId: row.id }),
-  }).catch(() => {});
-
-  return Response.json({ id: row.id });
+  return Response.json({ id: row.id, text });
 }

--- a/apps/web/app/teach/[courseId]/lectures/[lectureId]/page.tsx
+++ b/apps/web/app/teach/[courseId]/lectures/[lectureId]/page.tsx
@@ -1,6 +1,9 @@
 import { LiveTranscriptPanel } from "@/components/instructor/LiveTranscriptPanel";
 import { QuestionFeed } from "@/components/instructor/QuestionFeed";
+import { RecordingPendingProvider } from "@/components/instructor/RecordingPendingContext";
 import { SessionBar } from "@/components/instructor/SessionBar";
+import { lectureById } from "@/data/lectures";
+import { notFound } from "next/navigation";
 
 export default async function InstructorLecturePage({
   params,
@@ -8,22 +11,24 @@ export default async function InstructorLecturePage({
   params: Promise<{ courseId: string; lectureId: string }>;
 }) {
   const { courseId, lectureId } = await params;
-  // TODO: resolve real sessions.id from (courseId, lectureId) + auth. Using
-  // lectureId as the session key for now so the realtime loop is exercisable.
-  const sessionId = lectureId;
+  const lecture = lectureById(lectureId);
+  if (!lecture) notFound();
+  const sessionId = lecture.sessionId;
   const shareUrl = `/learn/${courseId}/lectures/${lectureId}/ask`;
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col">
-      <div className="grid min-h-0 flex-1 grid-cols-1 gap-4 p-4 lg:grid-cols-[minmax(0,1fr)_360px]">
-        <LiveTranscriptPanel sessionId={sessionId} />
-        <QuestionFeed sessionId={sessionId} />
+    <RecordingPendingProvider>
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+        <div className="grid min-h-0 flex-1 grid-cols-1 grid-rows-[minmax(0,1fr)] gap-4 overflow-hidden p-4 lg:grid-cols-[minmax(0,1fr)_380px]">
+          <LiveTranscriptPanel sessionId={sessionId} />
+          <QuestionFeed sessionId={sessionId} />
+        </div>
+        <SessionBar
+          sessionId={sessionId}
+          shareUrl={shareUrl}
+          courseId={courseId}
+        />
       </div>
-      <SessionBar
-        sessionId={sessionId}
-        shareUrl={shareUrl}
-        courseId={courseId}
-      />
-    </div>
+    </RecordingPendingProvider>
   );
 }

--- a/apps/web/components/in-lecture/AskPanel.tsx
+++ b/apps/web/components/in-lecture/AskPanel.tsx
@@ -1,7 +1,12 @@
 "use client";
 
+import {
+  renderWithCitations,
+  SourcesTray,
+} from "@/components/in-lecture/CitationPills";
 import { EmptyState } from "@/components/in-lecture/EmptyState";
-import { useStudentSession } from "@/components/in-lecture/StudentSessionContext";
+import { ToolCallChip } from "@/components/in-lecture/ToolCallChip";
+import { lectureById } from "@/data/lectures";
 import { useChat } from "@/lib/useChat";
 import type { Message } from "@/types/messages";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
@@ -30,21 +35,9 @@ const QUICK_PROMPTS: readonly string[] = [
   "What just happened?",
 ];
 
-// Quick prompts narrow grounding to "what just happened" so the answer stays
-// pinned to the last couple minutes of revealed transcript.
-const QUICK_PROMPT_WINDOW_SECONDS = 120;
-
 interface DeferredQuestion {
   id: string;
   content: string;
-}
-
-function parseTimestampToSeconds(ts: string): number {
-  const parts = ts.split(":").map((p) => Number.parseInt(p, 10));
-  if (parts.some(Number.isNaN)) return 0;
-  if (parts.length === 2) return parts[0] * 60 + parts[1];
-  if (parts.length === 3) return parts[0] * 3600 + parts[1] * 60 + parts[2];
-  return 0;
 }
 
 export default function AskPanel() {
@@ -53,14 +46,15 @@ export default function AskPanel() {
   const router = useRouter();
   const q = searchParams.get("q") ?? "";
 
-  const { messages, streaming, error, send } = useChat(lectureId ?? "demo");
-  const { lines } = useStudentSession();
+  const lecture = lectureId ? lectureById(lectureId) : undefined;
+  const sessionId = lecture?.sessionId ?? "";
+  const { messages, streaming, error, send } = useChat(
+    lectureId ?? "demo",
+    sessionId,
+  );
   const inputRef = useRef<HTMLInputElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
 
-  // Local draft; seeded from `?q=` when arriving from the transcript "Ask"
-  // button. Typing only updates local state — round-tripping through the URL
-  // was dropping characters.
   const [draft, setDraft] = useState<string>(q);
   const [prevQ, setPrevQ] = useState<string>(q);
   if (q !== prevQ) {
@@ -106,18 +100,11 @@ export default function AskPanel() {
     clearDraft();
   };
 
+  // Quick prompts no longer carry a hand-picked window — the model decides
+  // when to call get_recent vs search_lecture based on the phrasing.
   const sendQuickPrompt = (prompt: string) => {
     if (streaming) return;
-    const last = lines[lines.length - 1];
-    if (!last) {
-      send(prompt);
-      return;
-    }
-    const latestSec = parseTimestampToSeconds(last.timestamp);
-    send(prompt, {
-      uptoSeconds: latestSec + 1,
-      fromSeconds: Math.max(0, latestSec - QUICK_PROMPT_WINDOW_SECONDS),
-    });
+    send(prompt);
   };
 
   const onKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
@@ -231,56 +218,84 @@ function InLectureMessage({
   streaming: boolean;
 }): ReactNode {
   const hasContent = message.content.length > 0;
+  const tools = message.toolCalls ?? [];
+  if (!hasContent && tools.length === 0) {
+    return (
+      <div className="text-primary py-8 text-lg leading-9">
+        {streaming ? (
+          <span className="text-secondary inline-flex gap-1 text-base">
+            <span className="bg-secondary inline-block h-2 w-2 animate-pulse rounded-full" />
+            <span
+              className="bg-secondary inline-block h-2 w-2 animate-pulse rounded-full"
+              style={{ animationDelay: "120ms" }}
+            />
+            <span
+              className="bg-secondary inline-block h-2 w-2 animate-pulse rounded-full"
+              style={{ animationDelay: "240ms" }}
+            />
+          </span>
+        ) : null}
+      </div>
+    );
+  }
+
+  const prepped = normalizeMathDelimiters(message.content);
+  const cites = message.citations;
+
+  // ReactMarkdown emits text nodes as strings; swap citation markers inside
+  // each text node at render time.
+  const expandText = (children: ReactNode): ReactNode => {
+    if (typeof children === "string") return renderWithCitations(children, cites);
+    if (Array.isArray(children)) return children.map(expandText);
+    return children;
+  };
+
   return (
     <div className="text-primary py-8 text-lg leading-9">
-      {hasContent ? (
-        <ReactMarkdown
-          remarkPlugins={[remarkMath]}
-          rehypePlugins={[rehypeKatex]}
-          components={{
-            p: ({ children }) => <p className="mb-4 last:mb-0">{children}</p>,
-            strong: ({ children }) => (
-              <strong className="font-semibold">{children}</strong>
-            ),
-            em: ({ children }) => <em className="italic">{children}</em>,
-            ul: ({ children }) => (
-              <ul className="mb-4 list-disc pl-8 last:mb-0">{children}</ul>
-            ),
-            ol: ({ children }) => (
-              <ol className="mb-4 list-decimal pl-8 last:mb-0">{children}</ol>
-            ),
-            li: ({ children }) => <li className="mb-1">{children}</li>,
-            code: ({ children }) => (
-              <code className="bg-primary-tint/50 rounded px-1.5 py-0.5 font-mono text-base">
-                {children}
-              </code>
-            ),
-            h1: ({ children }) => (
-              <h1 className="mb-3 text-2xl font-semibold">{children}</h1>
-            ),
-            h2: ({ children }) => (
-              <h2 className="mb-3 text-xl font-semibold">{children}</h2>
-            ),
-            h3: ({ children }) => (
-              <h3 className="mb-2 text-lg font-semibold">{children}</h3>
-            ),
-          }}
-        >
-          {normalizeMathDelimiters(message.content)}
-        </ReactMarkdown>
-      ) : streaming ? (
-        <span className="text-secondary inline-flex gap-1 text-base">
-          <span className="bg-secondary inline-block h-2 w-2 animate-pulse rounded-full" />
-          <span
-            className="bg-secondary inline-block h-2 w-2 animate-pulse rounded-full"
-            style={{ animationDelay: "120ms" }}
-          />
-          <span
-            className="bg-secondary inline-block h-2 w-2 animate-pulse rounded-full"
-            style={{ animationDelay: "240ms" }}
-          />
-        </span>
+      {tools.length > 0 ? (
+        <div className="mb-4 flex flex-wrap gap-1.5">
+          {tools.map((t) => (
+            <ToolCallChip key={t.id} tool={t} />
+          ))}
+        </div>
       ) : null}
+      <ReactMarkdown
+        remarkPlugins={[remarkMath]}
+        rehypePlugins={[rehypeKatex]}
+        components={{
+          p: ({ children }) => (
+            <p className="mb-4 last:mb-0">{expandText(children)}</p>
+          ),
+          strong: ({ children }) => (
+            <strong className="font-semibold">{expandText(children)}</strong>
+          ),
+          em: ({ children }) => <em className="italic">{expandText(children)}</em>,
+          ul: ({ children }) => (
+            <ul className="mb-4 list-disc pl-8 last:mb-0">{children}</ul>
+          ),
+          ol: ({ children }) => (
+            <ol className="mb-4 list-decimal pl-8 last:mb-0">{children}</ol>
+          ),
+          li: ({ children }) => <li className="mb-1">{expandText(children)}</li>,
+          code: ({ children }) => (
+            <code className="bg-primary-tint/50 rounded px-1.5 py-0.5 font-mono text-base">
+              {children}
+            </code>
+          ),
+          h1: ({ children }) => (
+            <h1 className="mb-3 text-2xl font-semibold">{expandText(children)}</h1>
+          ),
+          h2: ({ children }) => (
+            <h2 className="mb-3 text-xl font-semibold">{expandText(children)}</h2>
+          ),
+          h3: ({ children }) => (
+            <h3 className="mb-2 text-lg font-semibold">{expandText(children)}</h3>
+          ),
+        }}
+      >
+        {prepped}
+      </ReactMarkdown>
+      <SourcesTray manifest={cites} />
     </div>
   );
 }

--- a/apps/web/components/in-lecture/CitationPills.tsx
+++ b/apps/web/components/in-lecture/CitationPills.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import type { CitationManifest, MaterialCitation } from "@/lib/qa";
+import type { ReactNode } from "react";
+
+// Two citation formats live in the answer text:
+//   [HH:MM]  → transcript moment (rendered as a pin that links to that line)
+//   [Mn]     → course-material chunk N (looked up in the manifest)
+const CITATION_RE = /\[(?:(\d{1,2}):(\d{2})|M(\d+))\]/g;
+
+export function renderWithCitations(
+  text: string,
+  manifest: CitationManifest | undefined,
+): ReactNode[] {
+  const materialsByN = new Map<number, MaterialCitation>(
+    manifest?.materials.map((m) => [m.n, m]) ?? [],
+  );
+  const out: ReactNode[] = [];
+  let lastIdx = 0;
+  let m: RegExpExecArray | null;
+  // Reset the regex's lastIndex since /g state persists across calls.
+  CITATION_RE.lastIndex = 0;
+  while ((m = CITATION_RE.exec(text)) !== null) {
+    if (m.index > lastIdx) out.push(text.slice(lastIdx, m.index));
+    if (m[1] && m[2]) {
+      const minutes = Number.parseInt(m[1], 10);
+      const seconds = Number.parseInt(m[2], 10);
+      const total = minutes * 60 + seconds;
+      out.push(
+        <TranscriptPin
+          key={`t-${m.index}`}
+          label={`${m[1]}:${m[2]}`}
+          totalSeconds={total}
+        />,
+      );
+    } else if (m[3]) {
+      const n = Number.parseInt(m[3], 10);
+      const mat = materialsByN.get(n);
+      if (mat) {
+        out.push(<MaterialPin key={`m-${m.index}-${n}`} citation={mat} />);
+      } else {
+        out.push(`[M${n}]`);
+      }
+    }
+    lastIdx = m.index + m[0].length;
+  }
+  if (lastIdx < text.length) out.push(text.slice(lastIdx));
+  return out;
+}
+
+function TranscriptPin({
+  label,
+  totalSeconds,
+}: {
+  label: string;
+  totalSeconds: number;
+}) {
+  return (
+    <a
+      href={`#transcript-${totalSeconds}`}
+      onClick={(e) => {
+        e.preventDefault();
+        const el = document.getElementById(`transcript-${totalSeconds}`);
+        if (el) {
+          el.scrollIntoView({ behavior: "smooth", block: "center" });
+          el.classList.add("ring-2", "ring-primary-accent");
+          window.setTimeout(
+            () => el.classList.remove("ring-2", "ring-primary-accent"),
+            1500,
+          );
+        }
+      }}
+      className="bg-primary-tint text-primary-accent-dark hover:bg-primary-accent mx-0.5 inline-flex items-center rounded px-1.5 py-0.5 align-baseline font-mono text-[10px] font-semibold no-underline transition hover:text-white"
+      title={`Lecture transcript at ${label}`}
+    >
+      {label}
+    </a>
+  );
+}
+
+function MaterialPin({ citation }: { citation: MaterialCitation }) {
+  const pageSuffix =
+    citation.pageNumber !== null ? ` · p${citation.pageNumber}` : "";
+  return (
+    <span
+      className="bg-secondary-tint text-secondary-accent-dark mx-0.5 inline-flex items-center rounded px-1.5 py-0.5 align-baseline text-[10px] font-semibold"
+      title={`${citation.materialTitle}${pageSuffix}`}
+    >
+      M{citation.n}
+    </span>
+  );
+}
+
+export function SourcesTray({
+  manifest,
+}: {
+  manifest: CitationManifest | undefined;
+}) {
+  if (!manifest || manifest.materials.length === 0) return null;
+  return (
+    <div className="border-divider bg-primary-bg/40 mt-4 flex flex-col gap-1.5 rounded-lg border p-3 text-xs">
+      <p className="text-secondary mb-1 text-[10px] font-semibold tracking-widest uppercase">
+        Course material citations
+      </p>
+      {manifest.materials.map((c) => (
+        <div key={c.n} className="flex items-start gap-2">
+          <span className="bg-secondary-tint text-secondary-accent-dark mt-0.5 inline-flex h-4 w-6 shrink-0 items-center justify-center rounded text-[10px] font-semibold">
+            M{c.n}
+          </span>
+          <span className="text-secondary">
+            {c.materialTitle}
+            {c.pageNumber !== null ? ` · p${c.pageNumber}` : ""}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/components/in-lecture/ToolCallChip.tsx
+++ b/apps/web/components/in-lecture/ToolCallChip.tsx
@@ -1,0 +1,48 @@
+import type { ToolEvent } from "@/lib/qa";
+import { MdSearch, MdHistoryToggleOff, MdAutoAwesome } from "react-icons/md";
+
+const ICONS: Record<string, React.ReactNode> = {
+  search_lecture: <MdSearch className="h-3.5 w-3.5" />,
+  get_recent: <MdHistoryToggleOff className="h-3.5 w-3.5" />,
+};
+
+function labelFor(tool: ToolEvent): string {
+  if (tool.name === "search_lecture") {
+    const q = (tool.args?.query as string | undefined) ?? "";
+    return q ? `Searched: "${q}"` : "Searched lecture";
+  }
+  if (tool.name === "get_recent") {
+    const s = tool.args?.seconds as number | undefined;
+    return s ? `Pulled last ${s}s of transcript` : "Pulled recent transcript";
+  }
+  return tool.name;
+}
+
+export function ToolCallChip({ tool }: { tool: ToolEvent }) {
+  const pending = tool.resultCount === undefined;
+  return (
+    <div className="bg-primary-tint/60 text-primary-accent-dark border-divider inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-[11px] font-medium">
+      <span className="text-primary-accent inline-flex items-center">
+        {ICONS[tool.name] ?? <MdAutoAwesome className="h-3.5 w-3.5" />}
+      </span>
+      <span>{labelFor(tool)}</span>
+      {pending ? (
+        <span className="text-primary-accent inline-flex gap-0.5">
+          <span className="bg-primary-accent inline-block h-1 w-1 animate-pulse rounded-full" />
+          <span
+            className="bg-primary-accent inline-block h-1 w-1 animate-pulse rounded-full"
+            style={{ animationDelay: "120ms" }}
+          />
+          <span
+            className="bg-primary-accent inline-block h-1 w-1 animate-pulse rounded-full"
+            style={{ animationDelay: "240ms" }}
+          />
+        </span>
+      ) : (
+        <span className="text-secondary text-[10px]">
+          {tool.resultCount} {tool.resultCount === 1 ? "hit" : "hits"}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/in-lecture/TranscriptPanel.tsx
+++ b/apps/web/components/in-lecture/TranscriptPanel.tsx
@@ -16,6 +16,8 @@ export default function TranscriptPanel() {
   }>();
   const router = useRouter();
   const { lines } = useStudentSession();
+  // TODO: switch to useLiveTranscript(lecture.sessionId) for real RAG-time
+  // live updates once auth/session resolution lands.
   const [selectedTimestamp, setSelectedTimestamp] = useState<string | null>(
     null,
   );

--- a/apps/web/components/instructor/AdvancedDrawer.tsx
+++ b/apps/web/components/instructor/AdvancedDrawer.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { TryRagPanel } from "@/components/instructor/TryRagPanel";
+import { useCallback, useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import { MdClose, MdRefresh, MdUploadFile } from "react-icons/md";
+
+export function AdvancedDrawer({
+  sessionId,
+  open,
+  onClose,
+}: {
+  sessionId: string;
+  open: boolean;
+  onClose: () => void;
+}) {
+  const [loadingSample, setLoadingSample] = useState(false);
+  const [resetting, setResetting] = useState(false);
+  const [msg, setMsg] = useState<string | null>(null);
+
+  // The SessionBar that renders us uses `backdrop-blur`, which per spec
+  // establishes a containing block for fixed-positioned descendants — so
+  // our `position: fixed` would resolve against the SessionBar instead of
+  // the viewport. Portal into document.body to escape that.
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+
+  const loadSample = useCallback(() => {
+    void (async () => {
+      setLoadingSample(true);
+      setMsg(null);
+      try {
+        const res = await fetch("/api/sessions/load-sample", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ sessionId }),
+        });
+        const json = (await res.json()) as {
+          inserted?: number;
+          embedded?: number;
+          error?: string;
+        };
+        if (!res.ok) throw new Error(json.error ?? `load-sample ${res.status}`);
+        setMsg(
+          `Loaded ${json.inserted ?? 0} lines · embedded ${json.embedded ?? 0}`,
+        );
+      } catch (err) {
+        setMsg(err instanceof Error ? err.message : "load-sample failed");
+      } finally {
+        setLoadingSample(false);
+        window.setTimeout(() => setMsg(null), 5000);
+      }
+    })();
+  }, [sessionId]);
+
+  const reset = useCallback(() => {
+    if (
+      typeof window !== "undefined" &&
+      !window.confirm(
+        "Reset session? This clears all transcript lines for this lecture.",
+      )
+    ) {
+      return;
+    }
+    void (async () => {
+      setResetting(true);
+      setMsg(null);
+      try {
+        const res = await fetch("/api/sessions/reset", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ sessionId }),
+        });
+        const json = (await res.json()) as {
+          deleted?: number;
+          error?: string;
+        };
+        if (!res.ok) throw new Error(json.error ?? `reset ${res.status}`);
+        setMsg(`Reset · ${json.deleted ?? 0} cleared`);
+      } catch (err) {
+        setMsg(err instanceof Error ? err.message : "reset failed");
+      } finally {
+        setResetting(false);
+        window.setTimeout(() => setMsg(null), 5000);
+      }
+    })();
+  }, [sessionId]);
+
+  if (!mounted) return null;
+
+  return createPortal(
+    <>
+      {/* Backdrop */}
+      <div
+        onClick={onClose}
+        aria-hidden
+        className={`fixed inset-0 z-30 bg-black/20 transition-opacity ${open ? "opacity-100" : "pointer-events-none opacity-0"}`}
+      />
+      {/* Drawer */}
+      <aside
+        role="dialog"
+        aria-label="Advanced settings"
+        className={`bg-primary-bg border-divider fixed top-0 right-0 z-40 flex h-full w-96 flex-col border-l shadow-xl transition-transform ${open ? "translate-x-0" : "translate-x-full"}`}
+      >
+        <div className="border-divider flex shrink-0 items-center justify-between border-b px-5 py-4">
+          <div>
+            <h2 className="text-primary text-sm font-semibold">
+              Advanced settings
+            </h2>
+            <p className="text-secondary text-xs">
+              Developer tools for this lecture session.
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            aria-label="Close"
+            className="text-secondary hover:text-primary hover:bg-stone-100 rounded-md p-1 transition"
+          >
+            <MdClose className="h-5 w-5" />
+          </button>
+        </div>
+
+        <div className="border-divider border-b p-5">
+          <p className="text-secondary mb-3 text-[11px] font-semibold tracking-widest uppercase">
+            Demo data
+          </p>
+          <div className="flex flex-col gap-2">
+            <button
+              onClick={loadSample}
+              disabled={loadingSample}
+              className="border-divider bg-primary-contr text-primary hover:bg-stone-50 flex items-center gap-2 rounded-md border px-3 py-2 text-sm font-medium transition disabled:opacity-50"
+            >
+              <MdUploadFile className="h-4 w-4" />
+              {loadingSample ? "Loading sample…" : "Load sample transcript"}
+            </button>
+            <button
+              onClick={reset}
+              disabled={resetting}
+              className="border-divider bg-primary-contr text-primary hover:bg-stone-50 flex items-center gap-2 rounded-md border px-3 py-2 text-sm font-medium transition disabled:opacity-50"
+            >
+              <MdRefresh className="h-4 w-4" />
+              {resetting ? "Resetting…" : "Reset this lecture"}
+            </button>
+            {msg && (
+              <p className="text-secondary pt-1 text-xs">{msg}</p>
+            )}
+          </div>
+        </div>
+
+        <div className="flex min-h-0 flex-1 flex-col p-5">
+          <p className="text-secondary mb-3 text-[11px] font-semibold tracking-widest uppercase">
+            RAG preview
+          </p>
+          <div className="flex min-h-0 flex-1">
+            <TryRagPanel sessionId={sessionId} />
+          </div>
+        </div>
+      </aside>
+    </>,
+    document.body,
+  );
+}

--- a/apps/web/components/instructor/LiveTranscriptPanel.tsx
+++ b/apps/web/components/instructor/LiveTranscriptPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { EmptyState } from "@/components/in-lecture/EmptyState";
+import { useRecordingPending } from "@/components/instructor/RecordingPendingContext";
 import { Card, CardBody, CardHeader } from "@/components/ui/Card";
 import { useLiveTranscript } from "@/lib/realtime/useLiveTranscript";
 import { useEffect, useRef } from "react";
@@ -8,6 +9,7 @@ import { MdGraphicEq } from "react-icons/md";
 
 export function LiveTranscriptPanel({ sessionId }: { sessionId: string }) {
   const items = useLiveTranscript(sessionId);
+  const { pending } = useRecordingPending();
   const scrollRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -15,19 +17,25 @@ export function LiveTranscriptPanel({ sessionId }: { sessionId: string }) {
       top: scrollRef.current.scrollHeight,
       behavior: "smooth",
     });
-  }, [items.length]);
+  }, [items.length, pending.length]);
+
+  const totalRows = items.length + pending.length;
 
   return (
     <Card className="h-full">
       <CardHeader
         title="Live transcript"
         right={
-          <span>{items.length === 0 ? "Idle" : `${items.length} lines`}</span>
+          <span>
+            {totalRows === 0
+              ? "Idle"
+              : `${items.length} lines${pending.length > 0 ? ` · ${pending.length} processing` : ""}`}
+          </span>
         }
       />
       <CardBody>
         <div ref={scrollRef} className="min-h-0 flex-1 overflow-y-auto">
-          {items.length === 0 ? (
+          {totalRows === 0 ? (
             <EmptyState
               icon={<MdGraphicEq />}
               title="Waiting for your lecture"
@@ -38,6 +46,7 @@ export function LiveTranscriptPanel({ sessionId }: { sessionId: string }) {
               {items.map((item) => (
                 <li
                   key={item.id}
+                  id={`transcript-${item.timestampSeconds}`}
                   className="flex gap-3 rounded-lg px-2 py-1.5 transition hover:bg-stone-50"
                 >
                   <span className="text-secondary shrink-0 pt-0.5 font-mono text-[11px] tabular-nums">
@@ -48,10 +57,31 @@ export function LiveTranscriptPanel({ sessionId }: { sessionId: string }) {
                   </span>
                 </li>
               ))}
+              {pending.map((p) => (
+                <PendingChunkRow key={p.id} />
+              ))}
             </ul>
           )}
         </div>
       </CardBody>
     </Card>
+  );
+}
+
+function PendingChunkRow() {
+  return (
+    <li
+      aria-busy="true"
+      aria-label="Transcribing chunk"
+      className="flex animate-pulse gap-3 rounded-lg px-2 py-1.5 opacity-70"
+    >
+      <span className="font-mono text-[11px] tabular-nums text-stone-400">
+        …
+      </span>
+      <span className="flex flex-1 flex-col gap-1.5">
+        <span className="block h-3 w-3/4 rounded bg-stone-200" />
+        <span className="block h-3 w-1/2 rounded bg-stone-200" />
+      </span>
+    </li>
   );
 }

--- a/apps/web/components/instructor/RecordingPendingContext.tsx
+++ b/apps/web/components/instructor/RecordingPendingContext.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useState,
+  type ReactNode,
+} from "react";
+
+export interface PendingChunk {
+  id: string;
+  sequence: number;
+  startedAt: number;
+}
+
+interface RecordingPendingState {
+  pending: PendingChunk[];
+  add: (entry: PendingChunk) => void;
+  remove: (id: string) => void;
+}
+
+const RecordingPendingCtx = createContext<RecordingPendingState | null>(null);
+
+export function RecordingPendingProvider({ children }: { children: ReactNode }) {
+  const [pending, setPending] = useState<PendingChunk[]>([]);
+  const add = useCallback(
+    (entry: PendingChunk) => setPending((p) => [...p, entry]),
+    [],
+  );
+  const remove = useCallback(
+    (id: string) => setPending((p) => p.filter((e) => e.id !== id)),
+    [],
+  );
+  return (
+    <RecordingPendingCtx.Provider value={{ pending, add, remove }}>
+      {children}
+    </RecordingPendingCtx.Provider>
+  );
+}
+
+export function useRecordingPending(): RecordingPendingState {
+  const ctx = useContext(RecordingPendingCtx);
+  if (!ctx)
+    throw new Error(
+      "useRecordingPending must be used inside RecordingPendingProvider",
+    );
+  return ctx;
+}

--- a/apps/web/components/instructor/SessionBar.tsx
+++ b/apps/web/components/instructor/SessionBar.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { AdvancedDrawer } from "@/components/instructor/AdvancedDrawer";
+import { useRecordingPending } from "@/components/instructor/RecordingPendingContext";
 import { Badge } from "@/components/ui/Badge";
 import { useLiveConfusion } from "@/lib/realtime/useLiveConfusion";
 import { useLiveQuestions } from "@/lib/realtime/useLiveQuestions";
@@ -13,9 +15,10 @@ import {
   MdFiberManualRecord,
   MdFlagCircle,
   MdStop,
+  MdTune,
 } from "react-icons/md";
 
-const CHUNK_MS = 8000;
+const CHUNK_MS = 10000;
 
 type Status = "idle" | "starting" | "recording" | "stopping" | "error";
 
@@ -44,6 +47,7 @@ export function SessionBar({
   const [now, setNow] = useState<number>(() => 0);
   const [copied, setCopied] = useState(false);
   const [ending, setEnding] = useState(false);
+  const [advancedOpen, setAdvancedOpen] = useState(false);
   const recorderRef = useRef<MediaRecorder | null>(null);
   const streamRef = useRef<MediaStream | null>(null);
   const seqRef = useRef(0);
@@ -56,6 +60,10 @@ export function SessionBar({
     confusion.re_explain +
     confusion.what_just_happened +
     confusion.give_example;
+  const { add: addPending, remove: removePending } = useRecordingPending();
+  // Re-keys the chunk-progress strip whenever a chunk flushes, restarting
+  // its CSS animation.
+  const [chunkTick, setChunkTick] = useState(0);
 
   useEffect(() => {
     if (status !== "recording") return;
@@ -64,8 +72,12 @@ export function SessionBar({
     return () => window.clearInterval(id);
   }, [status]);
 
+
+  const activeRef = useRef(false);
+
   const stop = useCallback(() => {
     setStatus("stopping");
+    activeRef.current = false;
     recorderRef.current?.stop();
     streamRef.current?.getTracks().forEach((t) => t.stop());
     recorderRef.current = null;
@@ -76,36 +88,70 @@ export function SessionBar({
 
   useEffect(() => () => stop(), [stop]);
 
+  function uploadChunk(blob: Blob, sequence: number) {
+    if (blob.size < 2000) return; // silence / sub-2KB flush
+    const pendingId = crypto.randomUUID();
+    addPending({ id: pendingId, sequence, startedAt: Date.now() });
+    const fd = new FormData();
+    fd.append("sessionId", sessionId);
+    fd.append("sequence", String(sequence));
+    fd.append("audio", blob, `chunk-${sequence}.webm`);
+    fetch("/api/transcribe", { method: "POST", body: fd })
+      .catch((err) => {
+        console.error("chunk upload failed", err);
+      })
+      .finally(() => {
+        removePending(pendingId);
+      });
+  }
+
+  // Records one self-contained ~CHUNK_MS WebM blob. Each cycle uses a fresh
+  // MediaRecorder so the resulting blob includes the EBML/WebM header —
+  // otherwise Groq Whisper rejects every chunk after the first as
+  // undecodable.
+  function recordOneChunk(stream: MediaStream): Promise<Blob | null> {
+    return new Promise((resolve) => {
+      const mime = MediaRecorder.isTypeSupported("audio/webm;codecs=opus")
+        ? "audio/webm;codecs=opus"
+        : "audio/webm";
+      const rec = new MediaRecorder(stream, { mimeType: mime });
+      recorderRef.current = rec;
+      const parts: BlobPart[] = [];
+      rec.ondataavailable = (e) => {
+        if (e.data && e.data.size > 0) parts.push(e.data);
+      };
+      rec.onstop = () => {
+        if (recorderRef.current === rec) recorderRef.current = null;
+        resolve(
+          parts.length > 0 ? new Blob(parts, { type: "audio/webm" }) : null,
+        );
+      };
+      rec.start();
+      window.setTimeout(() => {
+        if (rec.state !== "inactive") rec.stop();
+      }, CHUNK_MS);
+    });
+  }
+
   async function start() {
     setError(null);
     setStatus("starting");
     try {
       const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
       streamRef.current = stream;
-      const mime = MediaRecorder.isTypeSupported("audio/webm;codecs=opus")
-        ? "audio/webm;codecs=opus"
-        : "audio/webm";
-      const recorder = new MediaRecorder(stream, { mimeType: mime });
-      recorderRef.current = recorder;
       seqRef.current = 0;
-
-      recorder.ondataavailable = async (e) => {
-        if (!e.data || e.data.size === 0) return;
-        const sequence = seqRef.current++;
-        const fd = new FormData();
-        fd.append("sessionId", sessionId);
-        fd.append("sequence", String(sequence));
-        fd.append("audio", e.data, `chunk-${sequence}.webm`);
-        try {
-          await fetch("/api/transcribe", { method: "POST", body: fd });
-        } catch (err) {
-          console.error("chunk upload failed", err);
-        }
-      };
-
-      recorder.start(CHUNK_MS);
       setStartedAt(Date.now());
       setStatus("recording");
+      activeRef.current = true;
+
+      void (async () => {
+        while (activeRef.current && streamRef.current === stream) {
+          setChunkTick((t) => t + 1);
+          const blob = await recordOneChunk(stream);
+          if (!activeRef.current) break;
+          if (blob) uploadChunk(blob, seqRef.current++);
+        }
+      })();
     } catch (err) {
       setError(err instanceof Error ? err.message : "mic access failed");
       setStatus("error");
@@ -150,13 +196,24 @@ export function SessionBar({
   }, [courseId, recording, router, stop]);
 
   return (
-    <div className="border-divider bg-primary-contr/95 sticky bottom-0 z-20 border-t shadow-[0_-8px_24px_-12px_rgba(0,0,0,0.12)] backdrop-blur">
-      <div className="flex items-center gap-5 px-6 py-3">
+    <div className="border-divider bg-primary-contr/95 relative z-20 shrink-0 border-t shadow-[0_-8px_24px_-12px_rgba(0,0,0,0.12)] backdrop-blur">
+      {recording ? (
+        <div
+          key={chunkTick}
+          className="bg-primary-accent absolute top-0 left-0 h-0.5 origin-left"
+          style={{
+            animation: `sessionbar-chunk-fill ${CHUNK_MS}ms linear forwards`,
+            width: "100%",
+          }}
+        />
+      ) : null}
+      <style>{`@keyframes sessionbar-chunk-fill { from { transform: scaleX(0); } to { transform: scaleX(1); } }`}</style>
+      <div className="flex items-center gap-4 px-5 py-2.5">
         <button
           onClick={recording ? stop : start}
           disabled={status === "starting" || status === "stopping"}
           className={cn(
-            "flex items-center gap-2 rounded-full px-5 py-2.5 text-sm font-semibold text-white shadow-md transition disabled:opacity-50",
+            "flex shrink-0 items-center gap-2 whitespace-nowrap rounded-full px-4 py-2 text-sm font-semibold text-white shadow-md transition disabled:opacity-50",
             recording
               ? "bg-red-600 hover:bg-red-700"
               : "bg-primary-accent hover:bg-primary-accent-dark",
@@ -175,53 +232,96 @@ export function SessionBar({
           )}
         </button>
 
-        <div className="border-divider flex items-center gap-2 border-l pl-5">
+        <div className="border-divider flex min-w-0 items-center gap-3 border-l pl-4">
           {recording ? (
             <>
-              <span className="inline-block h-2 w-2 animate-pulse rounded-full bg-red-500" />
-              <span className="text-primary font-mono text-sm tabular-nums">
-                {formatElapsed(elapsed)}
-              </span>
-              <span className="text-secondary text-xs">live</span>
+              <div className="flex items-center gap-2">
+                <span className="inline-block h-2 w-2 shrink-0 animate-pulse rounded-full bg-red-500" />
+                <span className="text-primary font-mono text-sm tabular-nums">
+                  {formatElapsed(elapsed)}
+                </span>
+                <span className="text-secondary text-xs">live</span>
+              </div>
             </>
           ) : (
-            <span className="text-secondary text-xs">
-              {error ?? "Tap Record to start the lecture"}
+            <span className="text-secondary truncate text-xs">
+              {error ?? "Tap Record to start"}
             </span>
           )}
         </div>
 
-        <div className="border-divider hidden items-center gap-4 border-l pl-5 md:flex">
-          <Metric label="Transcript" value={`${transcript.length}`} />
-          <Metric label="Questions" value={`${questions.length}`} />
+        <div className="border-divider hidden shrink-0 items-center gap-4 border-l pl-4 lg:flex">
+          <Metric label="Lines" value={`${transcript.length}`} />
+          <Metric label="Qs" value={`${questions.length}`} />
           <ConfusionMeter total={confusionTotal} />
         </div>
 
-        <div className="ml-auto flex items-center gap-2">
-          <button
+        <div className="ml-auto flex shrink-0 items-center gap-1.5">
+          <IconButton
             onClick={copy}
-            className="text-secondary hover:text-primary border-divider flex items-center gap-2 rounded-md border px-3 py-1.5 text-xs font-medium transition hover:bg-stone-50"
-            aria-label="Copy student join link"
-          >
-            {copied ? (
-              <MdCheck className="text-primary-accent h-3.5 w-3.5" />
-            ) : (
-              <MdContentCopy className="h-3.5 w-3.5" />
-            )}
-            {copied ? "Copied" : "Copy student link"}
-          </button>
+            icon={
+              copied ? (
+                <MdCheck className="text-primary-accent h-4 w-4" />
+              ) : (
+                <MdContentCopy className="h-4 w-4" />
+              )
+            }
+            label={copied ? "Copied" : "Copy link"}
+            title="Copy the student join link to clipboard"
+          />
+          <IconButton
+            onClick={() => setAdvancedOpen(true)}
+            icon={<MdTune className="h-4 w-4" />}
+            label="Advanced"
+            title="Load sample, reset, and try RAG against this session"
+          />
           <button
             onClick={finish}
             disabled={ending}
-            className="flex items-center gap-2 rounded-md border border-red-200 bg-red-50 px-3 py-1.5 text-xs font-semibold text-red-700 transition hover:bg-red-100 disabled:opacity-50"
+            className="flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-md border border-red-200 bg-red-50 px-2.5 py-1.5 text-xs font-semibold text-red-700 transition hover:bg-red-100 disabled:opacity-50"
             aria-label="End lecture"
+            title="End the lecture and return to course view"
           >
-            <MdFlagCircle className="h-3.5 w-3.5" />
-            {ending ? "Ending…" : "End lecture"}
+            <MdFlagCircle className="h-4 w-4" />
+            <span className="hidden md:inline">
+              {ending ? "Ending…" : "End"}
+            </span>
           </button>
         </div>
       </div>
+      <AdvancedDrawer
+        sessionId={sessionId}
+        open={advancedOpen}
+        onClose={() => setAdvancedOpen(false)}
+      />
     </div>
+  );
+}
+
+function IconButton({
+  onClick,
+  disabled,
+  icon,
+  label,
+  title,
+}: {
+  onClick: () => void;
+  disabled?: boolean;
+  icon: React.ReactNode;
+  label: string;
+  title: string;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      title={title}
+      aria-label={label}
+      className="text-secondary hover:text-primary border-divider flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-md border px-2.5 py-1.5 text-xs font-medium transition hover:bg-stone-50 disabled:opacity-50"
+    >
+      {icon}
+      <span className="hidden md:inline">{label}</span>
+    </button>
   );
 }
 

--- a/apps/web/components/instructor/TryRagPanel.tsx
+++ b/apps/web/components/instructor/TryRagPanel.tsx
@@ -1,0 +1,173 @@
+"use client";
+
+import {
+  renderWithCitations,
+  SourcesTray,
+} from "@/components/in-lecture/CitationPills";
+import { ToolCallChip } from "@/components/in-lecture/ToolCallChip";
+import { Card, CardBody, CardHeader } from "@/components/ui/Card";
+import { useChat } from "@/lib/useChat";
+import type { Message } from "@/types/messages";
+import { useEffect, useRef, useState, type KeyboardEvent } from "react";
+import { MdScience, MdSend } from "react-icons/md";
+
+const SAMPLE_PROMPTS: readonly string[] = [
+  "What is the central limit theorem?",
+  "Explain convolution for summing dice",
+  "What was just said?",
+];
+
+export function TryRagPanel({ sessionId }: { sessionId: string }) {
+  const { messages, streaming, error, send } = useChat(sessionId, sessionId);
+  const [draft, setDraft] = useState("");
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    scrollRef.current?.scrollTo({
+      top: scrollRef.current.scrollHeight,
+      behavior: "smooth",
+    });
+  }, [messages]);
+
+  const submit = () => {
+    const trimmed = draft.trim();
+    if (!trimmed || streaming) return;
+    send(trimmed);
+    setDraft("");
+  };
+
+  const onKey = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key !== "Enter" || e.shiftKey) return;
+    e.preventDefault();
+    submit();
+  };
+
+  return (
+    <Card className="h-full">
+      <CardHeader title="Try RAG" right={<span>Instructor preview</span>} />
+      <CardBody>
+        <div ref={scrollRef} className="min-h-0 flex-1 overflow-y-auto">
+          {messages.length === 0 ? (
+            <div className="flex h-full flex-col items-center justify-center gap-4 p-6 text-center">
+              <div className="bg-primary-tint text-primary-accent flex h-12 w-12 items-center justify-center rounded-2xl text-xl">
+                <MdScience />
+              </div>
+              <div className="flex flex-col gap-1.5">
+                <p className="text-primary text-sm font-semibold">
+                  See what students get
+                </p>
+                <p className="text-secondary max-w-xs text-xs leading-relaxed">
+                  The model decides when to search the transcript or pull
+                  recent context. You&apos;ll see each tool call inline.
+                </p>
+              </div>
+              <div className="flex flex-col items-stretch gap-1.5 pt-1">
+                {SAMPLE_PROMPTS.map((p) => (
+                  <button
+                    key={p}
+                    onClick={() => send(p)}
+                    disabled={streaming}
+                    className="border-divider text-primary-accent-dark hover:bg-primary-tint rounded-md border px-3 py-1.5 text-left text-xs transition disabled:opacity-40"
+                  >
+                    {p}
+                  </button>
+                ))}
+              </div>
+            </div>
+          ) : (
+            <ul className="flex flex-col gap-3 p-4">
+              {messages.map((m) =>
+                m.role === "student" ? (
+                  <li
+                    key={m.id}
+                    className="bg-primary-tint text-primary-accent-dark max-w-[85%] self-end rounded-xl px-3 py-2 text-sm font-medium"
+                  >
+                    {m.content}
+                  </li>
+                ) : (
+                  <AssistantTurn key={m.id} message={m} streaming={streaming} />
+                ),
+              )}
+            </ul>
+          )}
+        </div>
+        <div className="border-divider border-t p-3">
+          {error && (
+            <p className="pb-2 text-xs text-red-600" role="alert">
+              {error}
+            </p>
+          )}
+          <div className="relative">
+            <input
+              type="text"
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              onKeyDown={onKey}
+              disabled={streaming}
+              placeholder={
+                streaming ? "Thinking…" : "Ask a question to test RAG"
+              }
+              className="focus:outline-primary-accent border-divider bg-primary-bg/40 text-primary w-full rounded-lg border px-3 py-2 pr-10 text-sm disabled:opacity-60"
+            />
+            <button
+              type="button"
+              onClick={submit}
+              disabled={!draft.trim() || streaming}
+              aria-label="Send"
+              className="bg-primary-accent hover:bg-primary-accent-dark absolute top-1/2 right-1.5 flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-full text-white shadow-sm transition disabled:cursor-not-allowed disabled:opacity-30"
+            >
+              <MdSend className="h-3.5 w-3.5" />
+            </button>
+          </div>
+        </div>
+      </CardBody>
+    </Card>
+  );
+}
+
+function AssistantTurn({
+  message,
+  streaming,
+}: {
+  message: Message;
+  streaming: boolean;
+}) {
+  const tools = message.toolCalls ?? [];
+  const cites = message.citations;
+  const content = message.content;
+  const hasAnything = content.length > 0 || tools.length > 0;
+
+  if (!hasAnything) {
+    return streaming ? (
+      <li className="text-secondary inline-flex gap-1 px-2 py-1 text-xs">
+        <span className="bg-secondary inline-block h-1.5 w-1.5 animate-pulse rounded-full" />
+        <span
+          className="bg-secondary inline-block h-1.5 w-1.5 animate-pulse rounded-full"
+          style={{ animationDelay: "120ms" }}
+        />
+        <span
+          className="bg-secondary inline-block h-1.5 w-1.5 animate-pulse rounded-full"
+          style={{ animationDelay: "240ms" }}
+        />
+      </li>
+    ) : null;
+  }
+
+  return (
+    <li className="flex flex-col gap-2 text-sm">
+      {tools.length > 0 ? (
+        <div className="flex flex-wrap gap-1.5">
+          {tools.map((t) => (
+            <ToolCallChip key={t.id} tool={t} />
+          ))}
+        </div>
+      ) : null}
+      {content && (
+        <p className="text-primary leading-6">
+          {renderWithCitations(content, cites)}
+        </p>
+      )}
+      <SourcesTray manifest={cites} />
+    </li>
+  );
+}

--- a/apps/web/data/lectures.ts
+++ b/apps/web/data/lectures.ts
@@ -1,7 +1,28 @@
 import type { Lecture } from "@/types/lectures";
 
+// Real sessions.id values from Postgres. Hand-mapped for now; once auth +
+// session management land, lectures will be fetched dynamically.
 export const lectures: Lecture[] = [
-  { id: "1", title: "1 - Counting", courseId: "cs-109" },
-  { id: "2", title: "2 - Combinatorics", courseId: "cs-109" },
-  { id: "3", title: "3 - What is Probability?", courseId: "cs-109" },
+  {
+    id: "1",
+    title: "1 - Counting",
+    courseId: "cs-109",
+    sessionId: "742bcd6f-0896-4a89-8e8c-91abbb11fd95",
+  },
+  {
+    id: "2",
+    title: "2 - Combinatorics",
+    courseId: "cs-109",
+    sessionId: "59d5f5c1-671c-4b6f-917b-f3d1f5d24282",
+  },
+  {
+    id: "3",
+    title: "3 - What is Probability?",
+    courseId: "cs-109",
+    sessionId: "00b10e74-4620-47d8-a298-5cddc8f4e087",
+  },
 ];
+
+export function lectureById(id: string): Lecture | undefined {
+  return lectures.find((l) => l.id === id);
+}

--- a/apps/web/lib/chunker.ts
+++ b/apps/web/lib/chunker.ts
@@ -1,0 +1,212 @@
+import "server-only";
+
+import { db } from "@/lib/db";
+import { transcriptChunks, transcriptItems } from "@spr26/db";
+import { openai } from "@ai-sdk/openai";
+import { embedMany } from "ai";
+import { and, asc, eq, gte, isNotNull, lte, sql } from "drizzle-orm";
+
+// Sliding-window config. Each chunk covers WINDOW utterances (~3min at our
+// 10s cadence) and the next chunk overlaps by OVERLAP to keep semantic
+// continuity across boundaries.
+export const WINDOW = 20;
+export const OVERLAP = 5;
+const STRIDE = WINDOW - OVERLAP; // 15
+
+const EMBED_MODEL = "text-embedding-3-small";
+
+async function maxExistingChunkEnd(sessionId: string): Promise<number | null> {
+  const [row] = await db()
+    .select({
+      max: sql<number | null>`MAX(${transcriptChunks.endSeq})::int`,
+    })
+    .from(transcriptChunks)
+    .where(eq(transcriptChunks.sessionId, sessionId));
+  return row?.max ?? null;
+}
+
+async function maxTranscriptSeq(sessionId: string): Promise<number | null> {
+  const [row] = await db()
+    .select({
+      max: sql<number | null>`MAX(${transcriptItems.sequence})::int`,
+    })
+    .from(transcriptItems)
+    .where(eq(transcriptItems.sessionId, sessionId));
+  return row?.max ?? null;
+}
+
+// Build every pending chunk for `sessionId` in order, embed them in one
+// batch, write back. Idempotent — if there's not enough new transcript to
+// justify the next chunk yet, it's a no-op.
+export async function buildPendingChunks(sessionId: string): Promise<{
+  built: number;
+}> {
+  const maxItemSeq = await maxTranscriptSeq(sessionId);
+  if (maxItemSeq === null) return { built: 0 };
+
+  const lastEnd = await maxExistingChunkEnd(sessionId); // -1 conceptually
+
+  const pendingRanges: { start: number; end: number }[] = [];
+  let nextStart =
+    lastEnd === null ? 0 : Math.max(0, lastEnd - OVERLAP + 1) + STRIDE - (STRIDE);
+  // Cleaner: derive starts directly.
+  if (lastEnd === null) {
+    nextStart = 0;
+  } else {
+    nextStart = Math.max(0, lastEnd + 1 - OVERLAP);
+  }
+
+  while (nextStart + WINDOW - 1 <= maxItemSeq) {
+    const end = nextStart + WINDOW - 1;
+    pendingRanges.push({ start: nextStart, end });
+    nextStart += STRIDE;
+  }
+
+  if (pendingRanges.length === 0) return { built: 0 };
+
+  // Fetch all items in one query covering all pending ranges.
+  const minStart = pendingRanges[0].start;
+  const maxEnd = pendingRanges[pendingRanges.length - 1].end;
+  const rows = await db()
+    .select({
+      sequence: transcriptItems.sequence,
+      timestampSeconds: transcriptItems.timestampSeconds,
+      content: transcriptItems.content,
+    })
+    .from(transcriptItems)
+    .where(
+      and(
+        eq(transcriptItems.sessionId, sessionId),
+        gte(transcriptItems.sequence, minStart),
+        lte(transcriptItems.sequence, maxEnd),
+      ),
+    )
+    .orderBy(asc(transcriptItems.sequence));
+
+  const bySeq = new Map(rows.map((r) => [r.sequence, r]));
+
+  type Pending = {
+    start: number;
+    end: number;
+    startTs: number;
+    endTs: number;
+    content: string;
+  };
+  const pending: Pending[] = [];
+
+  for (const range of pendingRanges) {
+    const items: typeof rows = [];
+    for (let s = range.start; s <= range.end; s++) {
+      const row = bySeq.get(s);
+      if (row) items.push(row);
+    }
+    if (items.length === 0) continue;
+    pending.push({
+      start: range.start,
+      end: range.end,
+      startTs: items[0].timestampSeconds,
+      endTs: items[items.length - 1].timestampSeconds,
+      content: items.map((it) => it.content).join(" "),
+    });
+  }
+
+  if (pending.length === 0) return { built: 0 };
+
+  if (!process.env.OPENAI_API_KEY) {
+    throw new Error(
+      "OPENAI_API_KEY is required to embed transcript chunks. Set it in apps/web/.env.local (and on Vercel) before chunking.",
+    );
+  }
+  const { embeddings } = await embedMany({
+    model: openai.embedding(EMBED_MODEL),
+    values: pending.map((p) => p.content),
+  });
+
+  for (let i = 0; i < pending.length; i++) {
+    const p = pending[i];
+    try {
+      await db()
+        .insert(transcriptChunks)
+        .values({
+          sessionId,
+          startSeq: p.start,
+          endSeq: p.end,
+          startTimestampSeconds: p.startTs,
+          endTimestampSeconds: p.endTs,
+          content: p.content,
+          embedding: embeddings[i],
+        });
+    } catch (err) {
+      // Likely unique-violation from a concurrent chunk run — safe to ignore.
+      const msg = err instanceof Error ? err.message : String(err);
+      if (!msg.includes("transcript_chunks_session_start_unique")) throw err;
+    }
+  }
+
+  return { built: pending.length };
+}
+
+// Backfills embeddings for any chunks that were inserted without one
+// (typically when OPENAI_API_KEY wasn't set at insert time). Used by cron.
+export async function backfillChunkEmbeddings(): Promise<{ embedded: number }> {
+  if (!process.env.OPENAI_API_KEY) {
+    throw new Error(
+      "OPENAI_API_KEY is required to embed transcript chunks. Set it in apps/web/.env.local (and on Vercel) before chunking.",
+    );
+  }
+  const rows = await db()
+    .select({
+      id: transcriptChunks.id,
+      content: transcriptChunks.content,
+    })
+    .from(transcriptChunks)
+    .where(sql`${transcriptChunks.embedding} IS NULL`)
+    .limit(50);
+
+  if (rows.length === 0) return { embedded: 0 };
+
+  const { embeddings } = await embedMany({
+    model: openai.embedding(EMBED_MODEL),
+    values: rows.map((r) => r.content),
+  });
+
+  for (let i = 0; i < rows.length; i++) {
+    await db()
+      .update(transcriptChunks)
+      .set({ embedding: embeddings[i] })
+      .where(eq(transcriptChunks.id, rows[i].id));
+  }
+
+  return { embedded: rows.length };
+}
+
+// Cosine search over transcript_chunks for a given session.
+export async function searchChunks({
+  sessionId,
+  queryEmbedding,
+  k = 4,
+}: {
+  sessionId: string;
+  queryEmbedding: number[];
+  k?: number;
+}) {
+  const vec = `[${queryEmbedding.join(",")}]`;
+  return await db()
+    .select({
+      id: transcriptChunks.id,
+      startSeq: transcriptChunks.startSeq,
+      endSeq: transcriptChunks.endSeq,
+      startTimestampSeconds: transcriptChunks.startTimestampSeconds,
+      endTimestampSeconds: transcriptChunks.endTimestampSeconds,
+      content: transcriptChunks.content,
+    })
+    .from(transcriptChunks)
+    .where(
+      and(
+        eq(transcriptChunks.sessionId, sessionId),
+        isNotNull(transcriptChunks.embedding),
+      ),
+    )
+    .orderBy(sql`${transcriptChunks.embedding} <=> ${vec}::vector`)
+    .limit(k);
+}

--- a/apps/web/lib/qa.ts
+++ b/apps/web/lib/qa.ts
@@ -1,27 +1,46 @@
 import { iterSse, safeJson } from "@/lib/sse";
 
+export interface MaterialCitation {
+  n: number;
+  materialId: string;
+  materialTitle: string;
+  chunkId: string;
+  pageNumber: number | null;
+  preview: string;
+}
+
+export interface CitationManifest {
+  materials: MaterialCitation[];
+}
+
+export interface ToolEvent {
+  id: string;
+  name: string;
+  args?: Record<string, unknown>;
+  resultCount?: number;
+}
+
 export interface StreamQaArgs {
   question: string;
-  uptoSeconds: number;
-  /** Optional lower-bound (seconds) — used by windowed quick prompts. */
-  fromSeconds?: number;
+  sessionId: string;
   signal?: AbortSignal;
 }
 
-// POSTs the question (so it can be long) with `t`/`f` in the query string,
-// reads SSE deltas, yields plain strings.
+export type QaEvent =
+  | { type: "delta"; delta: string }
+  | { type: "tool_call"; tool: ToolEvent }
+  | { type: "tool_result"; tool: ToolEvent }
+  | { type: "citations"; citations: CitationManifest };
+
 export async function* streamQa({
   question,
-  uptoSeconds,
-  fromSeconds,
+  sessionId,
   signal,
-}: StreamQaArgs): AsyncGenerator<string, void, void> {
-  const params = new URLSearchParams({ t: String(uptoSeconds) });
-  if (fromSeconds !== undefined) params.set("f", String(fromSeconds));
-  const res = await fetch(`/api/qa?${params.toString()}`, {
+}: StreamQaArgs): AsyncGenerator<QaEvent, void, void> {
+  const res = await fetch("/api/qa", {
     method: "POST",
     headers: { "content-type": "application/json" },
-    body: JSON.stringify({ question }),
+    body: JSON.stringify({ question, sessionId }),
     signal,
   });
 
@@ -31,7 +50,29 @@ export async function* streamQa({
       const parsed = safeJson(evt.data) as { error?: string } | null;
       throw new Error(parsed?.error ?? "qa stream errored");
     }
+    if (evt.event === "tool_call") {
+      const p = safeJson(evt.data) as ToolEvent | null;
+      if (p) yield { type: "tool_call", tool: p };
+      continue;
+    }
+    if (evt.event === "tool_result") {
+      const p = safeJson(evt.data) as
+        | { id: string; name: string; count?: number }
+        | null;
+      if (p) {
+        yield {
+          type: "tool_result",
+          tool: { id: p.id, name: p.name, resultCount: p.count },
+        };
+      }
+      continue;
+    }
+    if (evt.event === "citations") {
+      const parsed = safeJson(evt.data) as CitationManifest | null;
+      if (parsed) yield { type: "citations", citations: parsed };
+      continue;
+    }
     const parsed = safeJson(evt.data) as { delta?: string } | null;
-    if (parsed?.delta) yield parsed.delta;
+    if (parsed?.delta) yield { type: "delta", delta: parsed.delta };
   }
 }

--- a/apps/web/lib/realtime/useLiveTranscript.ts
+++ b/apps/web/lib/realtime/useLiveTranscript.ts
@@ -13,13 +13,18 @@ interface DbRow {
 
 function rowToItem(
   row: DbRow,
-): TranscriptItem & { id: string; sequence: number } {
+): TranscriptItem & {
+  id: string;
+  sequence: number;
+  timestampSeconds: number;
+} {
   const m = Math.floor(row.timestamp_seconds / 60);
   const s = row.timestamp_seconds % 60;
   return {
     id: row.id,
     sequence: row.sequence,
-    timestamp: `${m}:${String(s).padStart(2, "0")}`,
+    timestamp: `${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`,
+    timestampSeconds: row.timestamp_seconds,
     content: row.content,
   };
 }
@@ -28,7 +33,11 @@ function rowToItem(
 // plus any inserts that arrive over Supabase Realtime, sorted by sequence.
 export function useLiveTranscript(sessionId: string | null) {
   const [items, setItems] = useState<
-    (TranscriptItem & { id: string; sequence: number })[]
+    (TranscriptItem & {
+      id: string;
+      sequence: number;
+      timestampSeconds: number;
+    })[]
   >([]);
 
   useEffect(() => {

--- a/apps/web/lib/useChat.ts
+++ b/apps/web/lib/useChat.ts
@@ -1,35 +1,27 @@
 "use client";
 
-import { streamQa } from "@/lib/qa";
+import { streamQa, type CitationManifest } from "@/lib/qa";
 import type { Message } from "@/types/messages";
 import { useCallback, useRef, useState } from "react";
 
-// Typewriter knobs: incoming model deltas are buffered, then revealed at a
-// steady cadence so wildly variable token sizes don't cause visible stutter.
-// Per tick we drain ~1/TARGET_TICKS of the buffer.
 const TYPEWRITER_TICK_MS = 25;
 const TYPEWRITER_TARGET_TICKS = 20;
-
-export interface SendOptions {
-  fromSeconds?: number;
-  uptoSeconds?: number;
-}
 
 export interface UseChatResult {
   messages: Message[];
   streaming: boolean;
   error: string | null;
-  send: (question: string, opts?: SendOptions) => void;
+  send: (question: string) => void;
 }
 
-export function useChat(lectureId: string): UseChatResult {
+export function useChat(lectureId: string, sessionId: string): UseChatResult {
   const [messages, setMessages] = useState<Message[]>([]);
   const [streaming, setStreaming] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const abortRef = useRef<AbortController | null>(null);
 
   const send = useCallback(
-    (question: string, opts?: SendOptions): void => {
+    (question: string): void => {
       const trimmed = question.trim();
       if (!trimmed || streaming) return;
 
@@ -44,16 +36,21 @@ export function useChat(lectureId: string): UseChatResult {
       setMessages((prev) => [
         ...prev,
         { id: studentId, content: trimmed, role: "student", lectureId },
-        { id: assistantId, content: "", role: "inLecture", lectureId },
+        {
+          id: assistantId,
+          content: "",
+          role: "inLecture",
+          lectureId,
+          toolCalls: [],
+        },
       ]);
 
-      void run(ac.signal, assistantId, trimmed, opts);
+      void run(ac.signal, assistantId, trimmed);
 
       async function run(
         signal: AbortSignal,
         targetId: string,
         q: string,
-        windowOpts?: SendOptions,
       ): Promise<void> {
         const buf = { text: "" };
         let streamDone = false;
@@ -86,14 +83,41 @@ export function useChat(lectureId: string): UseChatResult {
           }, TYPEWRITER_TICK_MS);
         });
 
+        let citations: CitationManifest | undefined;
         try {
-          for await (const delta of streamQa({
+          for await (const evt of streamQa({
             question: q,
-            uptoSeconds: windowOpts?.uptoSeconds ?? Number.MAX_SAFE_INTEGER,
-            fromSeconds: windowOpts?.fromSeconds,
+            sessionId,
             signal,
           })) {
-            buf.text += delta;
+            if (evt.type === "delta") {
+              buf.text += evt.delta;
+            } else if (evt.type === "tool_call") {
+              setMessages((prev) =>
+                prev.map((m) =>
+                  m.id === targetId
+                    ? {
+                        ...m,
+                        toolCalls: [...(m.toolCalls ?? []), evt.tool],
+                      }
+                    : m,
+                ),
+              );
+            } else if (evt.type === "tool_result") {
+              setMessages((prev) =>
+                prev.map((m) => {
+                  if (m.id !== targetId) return m;
+                  const next = (m.toolCalls ?? []).map((t) =>
+                    t.id === evt.tool.id
+                      ? { ...t, resultCount: evt.tool.resultCount }
+                      : t,
+                  );
+                  return { ...m, toolCalls: next };
+                }),
+              );
+            } else if (evt.type === "citations") {
+              citations = evt.citations;
+            }
           }
         } catch (err) {
           if (!signal.aborted) {
@@ -104,10 +128,17 @@ export function useChat(lectureId: string): UseChatResult {
         }
 
         await drain;
+        if (citations && !signal.aborted) {
+          setMessages((prev) =>
+            prev.map((m) =>
+              m.id === targetId ? { ...m, citations } : m,
+            ),
+          );
+        }
         if (!signal.aborted) setStreaming(false);
       }
     },
-    [lectureId, streaming],
+    [lectureId, sessionId, streaming],
   );
 
   return { messages, streaming, error, send };

--- a/apps/web/types/lectures.ts
+++ b/apps/web/types/lectures.ts
@@ -2,4 +2,7 @@ export interface Lecture {
   id: string;
   title: string;
   courseId: string;
+  /** Real sessions.id (UUID) in Postgres. Threaded through to the API for
+   *  transcribe / load-sample / reset / RAG. */
+  sessionId: string;
 }

--- a/apps/web/types/messages.ts
+++ b/apps/web/types/messages.ts
@@ -1,6 +1,10 @@
+import type { CitationManifest, ToolEvent } from "@/lib/qa";
+
 export interface Message {
   id: string;
   content: string;
   role: "student" | "inLecture";
   lectureId: string;
+  citations?: CitationManifest;
+  toolCalls?: ToolEvent[];
 }

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -7,6 +7,9 @@
   "functions": {
     "app/api/transcribe/route.ts": { "maxDuration": 60 },
     "app/api/embed/route.ts": { "maxDuration": 60 },
-    "app/api/qa/route.ts": { "maxDuration": 60 }
-  }
+    "app/api/chunk/route.ts": { "maxDuration": 60 },
+    "app/api/qa/route.ts": { "maxDuration": 60 },
+    "app/api/sessions/load-sample/route.ts": { "maxDuration": 60 }
+  },
+  "crons": []
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -203,6 +203,40 @@ export const transcriptItems = pgTable(
   ],
 ).enableRLS();
 
+// Sliding-window chunks of transcript_items used for RAG retrieval. Each
+// chunk concatenates ~20 consecutive utterances (~3 min of speech) with a
+// 5-item overlap to its neighbors, so retrieval has enough semantic context
+// per match.
+export const transcriptChunks = pgTable(
+  "transcript_chunks",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    sessionId: uuid("session_id")
+      .notNull()
+      .references(() => sessions.id, { onDelete: "cascade" }),
+    startSeq: integer("start_seq").notNull(),
+    endSeq: integer("end_seq").notNull(),
+    startTimestampSeconds: integer("start_timestamp_seconds").notNull(),
+    endTimestampSeconds: integer("end_timestamp_seconds").notNull(),
+    content: text("content").notNull(),
+    embedding: vector("embedding"),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (t) => [
+    check("transcript_chunks_seq_order", sql`${t.endSeq} >= ${t.startSeq}`),
+    unique("transcript_chunks_session_start_unique").on(
+      t.sessionId,
+      t.startSeq,
+    ),
+    index("transcript_chunks_session_end_idx").on(t.sessionId, t.endSeq),
+    index("transcript_chunks_embedding_idx")
+      .using("hnsw", sql`${t.embedding} vector_cosine_ops`)
+      .where(sql`${t.embedding} IS NOT NULL`),
+  ],
+).enableRLS();
+
 export const courseMaterials = pgTable("course_materials", {
   id: uuid("id").primaryKey().defaultRandom(),
   courseId: uuid("course_id")
@@ -426,3 +460,5 @@ export type CourseMaterial = typeof courseMaterials.$inferSelect;
 export type NewCourseMaterial = typeof courseMaterials.$inferInsert;
 export type CourseMaterialChunk = typeof courseMaterialChunks.$inferSelect;
 export type NewCourseMaterialChunk = typeof courseMaterialChunks.$inferInsert;
+export type TranscriptChunk = typeof transcriptChunks.$inferSelect;
+export type NewTranscriptChunk = typeof transcriptChunks.$inferInsert;


### PR DESCRIPTION
## Summary

- **Live transcription pipeline** end-to-end: instructor records → 10s WebM chunks → Groq Whisper → \`transcript_items\` insert → Supabase Realtime delivers to all subscribed clients.
- **QA over the full transcript** (no chunking for transcript — it fits Opus context). RAG kept and now wired to a \`search_course_materials\` tool for uploaded docs (slides, notes, readings).
- **Citations** in two formats: \`[HH:MM]\` for transcript moments (clickable, scrolls + ring-highlights the cited line in the live transcript card) and \`[Mn]\` for course-material chunks (Sources tray with title + page).
- **Instructor Advanced drawer**: Load sample transcript / Reset session / Try RAG (mirrors what students will get, streams answers with citation pills + tool-call chips).
- **Per-chunk skeleton row** in the live transcript while Whisper is processing — disappears when the real row lands via realtime.

## Key fixes

- **MediaRecorder header bug**: \`recorder.start(timeslice)\` produces fragmented WebM where only the first chunk has the EBML header → every subsequent chunk got rejected by Whisper with a 502. Now each 10s window spins up a fresh \`MediaRecorder\` so every uploaded blob is a complete WebM file.
- **Duplicate-sequence violations** on Record → Stop → Record: \`/api/transcribe\` now picks the next sequence as \`MAX(existing) + 1\` per session.
- **Empty/silence detection**: \`/api/transcribe\` drops sub-2KB payloads and known Whisper noise outputs (\"you\", \"thank you\", etc).
- **AdvancedDrawer escapes the backdrop-blur containing block** via React portal to \`document.body\` (CSS spec: \`backdrop-filter\` creates a containing block for fixed-positioned descendants).
- **Int4 overflow**: \`/api/qa\` caps and drops oversized \`uptoSeconds\` instead of passing \`Number.MAX_SAFE_INTEGER\` to the int4 \`timestamp_seconds\` column.

## DB / infra

- New \`transcript_chunks\` table + HNSW cosine index (kept for future course-material reuse; transcripts no longer chunked).
- Three permissive demo SELECT RLS policies on \`transcript_items\` / \`questions\` / \`quick_prompt_signals\` / \`transcript_chunks\` so realtime delivers rows to the anon client. Tighten when auth lands.
- Migrations applied to remote via Supabase MCP.
- \`vercel.json\` no longer schedules a chunk cron.

## Required env vars (Vercel project Settings → Environment Variables)

| Key | Value source |
| --- | --- |
| \`NEXT_PUBLIC_SUPABASE_URL\` | Supabase Settings → API |
| \`NEXT_PUBLIC_SUPABASE_ANON_KEY\` | Supabase Settings → API (anon key) |
| \`DATABASE_URL\` | Supabase Settings → Database → Connection string → **Transaction** (port 6543) |
| \`OPENAI_API_KEY\` | OpenAI dashboard (for embeddings + answer generation) |
| \`ANTHROPIC_API_KEY\` | Anthropic console (optional; preferred over OpenAI for generation) |
| \`GROQ_API_KEY\` | console.groq.com (Whisper-large-v3-turbo) |

## Test plan

- [ ] \`npm install && npm run dev\`
- [ ] /teach/cs-109/lectures/1 → Advanced → Load sample → 414 rows in ~2s
- [ ] /teach/cs-109/lectures/1 → Advanced → Try RAG: "What is convolution?" → answer streams with \`[02:13]\`-style pins
- [ ] Click a transcript pin → live transcript card scrolls to the cited line + ring-highlight
- [ ] /teach/cs-109/lectures/1 → Record → 10s chunks arrive as 200s on \`/api/transcribe\`, skeleton row appears + replaces with real text
- [ ] \`npm run build -w @spr26/web\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)